### PR TITLE
Replace a usage of extern with external

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -4857,7 +4857,7 @@ function-body := function-body-block | external-function-body
 external-function-body := <code>=</code> annots <code>external</code> <code>;</code>
 </pre>
 <p>
-An <code>extern-function-body</code> means that the implementation of the
+An <code>external-function-body</code> means that the implementation of the
 function is not provided in the Ballerina source module.
 </p>
 <h3>Service declaration</h3>


### PR DESCRIPTION
The grammar production `extern-function-body` has been changed to `external-function-body` recently. I found a single usage of `extern-function-body` in the spec. This PR updates that usage.