### PR TITLE
Fix a typo in Function value description

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -1189,7 +1189,7 @@ rest-param only when occuring in the function-signature of a
 function-type-descriptor.
 </p>
 <p>
-The argument list passed to a function consists of zero or arguments in order;
+The argument list passed to a function consists of zero or more arguments in order;
 each argument is a value, but the argument list itself is not passed as a value.
 The argument list must conform to the param-list as described in this section.
 Usually, the compiler's type checking will ensure that this is the case; if not,


### PR DESCRIPTION
This PR fixes a small typo in the function value description