### PR TITLE
Fix a typo [s/const-ref.../constant-ref.../g]

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -2367,7 +2367,7 @@ class="grammar">simple-const-expr :=
   | [Sign] int-literal
   | [Sign] floating-point-literal
   | string-literal
-  | const-reference-expr
+  | constant-reference-expr
 </pre>
 <p>
 A simple-const-expr is a restricted form of const-expr used in contexts where


### PR DESCRIPTION
This PR fixes a small typo in the spec. 