### PR TITLE
Fix typos and reserve "ballerina" org in all repos

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -201,6 +201,10 @@ associated with a separate binary module. Versions are semantic, as described in
 the SemVer specification.
 </p>
 <p>
+The organization name <code>ballerina</code> is reserved for use by the 
+Ballerina platform in any repository.
+</p>
+<p>
 A project stores modules using a simpler single level hierarchy, in which the
 module is associated directly with the module name.
 </p>
@@ -345,7 +349,7 @@ in Ballerina represent not just trees but graphs.
 <p>
 Simple values are inherently immutable because they have no identity distinct
 from their value. All basic types of structural values, with the exception of
-the XML, are mutable, meaning the value referred to by a particular reference
+XML, are mutable, meaning the value referred to by a particular reference
 can be changed. Whether a behavioral value is mutable depends on its basic
 type: some of the behavioral basic types allow mutation, and some do not.
 Mutation cannot change the basic type of a value. Mutation makes it possible for
@@ -571,7 +575,7 @@ use of null should be restricted to JSON-related contexts.
 <p>
 The nil type is special, in that it is the only basic type that consists of a
 single value. The type descriptor for the nil type is not written using a
-keyword, but is instead written <code>() </code>like the value.
+keyword, but is instead written <code>()</code>like the value.
 </p>
 <h4>Boolean</h4>
 


### PR DESCRIPTION
The spec doesn't appear to require that "ballerina" is reserved in all orgs.

Others are minor typos (and I will probably see more).