### PR TITLE
Fix a typo

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -4151,7 +4151,7 @@ Each thread is divided into one or more <em>strands</em>. No two strands
 belonging to the same thread can run simultaneously. Instead, all the strands
 belonging to a particular thread are cooperatively multitasked. Strands within
 the same thread thus behave as coroutines relative to each other. A strand
-enables cooeperative multitasking by <em>yielding</em>. When a strand yields,
+enables cooperative multitasking by <em>yielding</em>. When a strand yields,
 the runtime scheduler may suspend execution of the strand, and switch its thread
 to executing another strand. The following actions cause a strand to yield:
 </p>


### PR DESCRIPTION
s/cooeperative/cooperative/g