### PR TITLE
Update Clone(V) description to fix a typo

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -2674,7 +2674,7 @@ a basic type that has an inherent type, Clone(v) has the same inherent type as
 v. The graph of references of Clone(v) must have the same structure as that of
 v. This implies that the number of distinct references reachable from Clone(v)
 must be the same as the number of distinct references reachable from v. Clone(v)
-must terminate even if v has cycles.
+must continue even if v has cycles.
 </p>
 <p>
 Clone(v) cannot be implemented simply by recursively calling Clone on all


### PR DESCRIPTION
The Clone(V) abstract operation description has the following sentence. 
`Clone(v) must terminate even if v has cycles.`

It should be corrected as follows. 

`Clone(v) must continue even if v has cycles.`
