### PR TITLE
Remove the section where `error` type is mentioned

### DIFF
--- a/lang/lib/value.bal
+++ b/lang/lib/value.bal
@@ -66,8 +66,7 @@ public function cloneReadOnly(CloneableType v) returns CloneableType = external;
 # - the graph structure of `v` is not preserved; the result will always be a tree;
 #   an error will be returned if `v` has cycles
 # - immutable structural values are copied rather being returned as is; all
-#   structural values in the result will be mutable, except for error values
-#   (which are always immutable)
+#   structural values in the result will be mutable.
 # - numeric values can be converted using the NumericConvert abstract operation
 # - if a record type descriptor specifies default values, these will be used
 #   to supply any missing members


### PR DESCRIPTION
The `error` type is no longer a structured type.
