### PR TITLE
Removed invalid "are" from 5.2.3 "Int" section

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -972,7 +972,7 @@ a two's complement representation).
 </p>
 <p>
 The <a href="#byte_type"><code>byte</code> type</a> is a subtype of
-<code>int</code>. The <code>lang.int</code> lang library module are also
+<code>int</code>. The <code>lang.int</code> lang library module also
 provides <a href="#built-in_subtypes">built-in subtypes</a> for signed and
 unsigned integers representable in 8, 16 and 32 bits.
 </p>


### PR DESCRIPTION
## Purpose
Removed an invalid "are" being used in section 5.2.3 (Int). Changed `The lang.int lang library module are also provides...` to `The lang.int lang library module also provides...`.
