### PR TITLE
Fix broken link for ordered types

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -5940,7 +5940,7 @@ class="grammar">relational-expr :=
 </pre>
 <p>
 A relational-expr tests the relative order of two values. There must be an <a
-href="#ordered">ordered</a> type to which the static type of both operands
+href="#ordering">ordered</a> type to which the static type of both operands
 belong. The static type of the result is boolean.
 </p>
 <p>
@@ -6435,7 +6435,7 @@ order-direction := <code>ascending</code> | <code>descending</code>
 </pre>
 <p>
 The static type of the expression in an order-key must be an <a
-href="#ordered">ordered</a> type. The order-direction is <code>ascending</code>
+href="#ordering">ordered</a> type. The order-direction is <code>ascending</code>
 if not explicitly specified.
 </p>
 <p>


### PR DESCRIPTION
## Purpose
Changed to point to the section on "Ordering", since there's no separate section for "ordered types".