### PR TITLE
Fix typos

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -5486,13 +5486,13 @@ named-arg specifies a field of the error detail mapping; the static type of each
 named-arg must be a subtype of <code>value:Cloneable</code>. The type descriptor
 E implies a type descriptor D for the detail mapping. The arg-name of every
 named-arg must be specified as the field-name of an individual-field-descriptor
-occurring in D, unless there are no are no such field names. Fields with default
+occurring in D, unless there are no such field names. Fields with default
 values will also be added to the detail record based on D in the same way as the
 mapping-constructor-expr adds fields with default values based on the
 contextually expected type. The contextually expected type for each named-arg is
 determined from D in the same way as for a mapping-constructor-expr. The detail
 mapping is constructed as immutable, with its members being the result of
-appplying the ImmutableClone abstract operation to the result of evaluating each
+applying the ImmutableClone abstract operation to the result of evaluating each
 named-arg and every defaultable arg.
 </p>
 <p>


### PR DESCRIPTION
## Purpose
Fix two typos in the "error constructor expression" section.