### PR TITLE
Fix object symbol space in change summary

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -10359,7 +10359,7 @@ descriptors are what was previously called <em>abstract</em>: they declare
 methods but do not define them. Objects are now created either by using an
 object constructor expression, which includes method definitions, or by applying
 <code>new</code> to the name of a class defined by a class definition. The
-methods and fields of an object are not in a single symbol space. Classes and
+methods and fields of an object are in a single symbol space. Classes and
 object constructors can declare fields as final.</li>
 <li>Services have become service objects that work in a similar way to client
 objects; resource methods on service objects have become remote methods. Remote


### PR DESCRIPTION
## Purpose
Point 1 of the "Summary of changes from 2020R1 to Swan Lake" section seems to say

> The methods and fields of an object are **not** in a single symbol space.

This PR removes "not" since they are in a single symbol space now.