### PR TITLE
Add boolean to allowed contextually-expected type for lax access with check

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -6233,7 +6233,7 @@ or <code>checkpanic <var>Expr</var></code> is T. However, if:
 <li>the static type of <code><var>Expr</var></code> is lax,</li>
 <li>T is a subtype of <code>json</code>, and</li>
 <li>there is a contextually expected type S, where S is a subtype of
-<code>()|int|float|decimal|string</code>,</li>
+<code>()|boolean|int|float|decimal|string</code>,</li>
 </ul>
 <p>
 then instead <code>check <var>Expr</var></code> is treated as <code>check


### PR DESCRIPTION
## Purpose
Add boolean to allowed contextually-expected type for lax access with check, assuming this should be allowed because it is not a structured type.