### PR TITLE
Add conformance tests for maps

### DIFF
--- a/conformance/lang/values-types-and-variables/map_types.balt
+++ b/conformance/lang/values-types-and-variables/map_types.balt
@@ -120,69 +120,69 @@ public function main() {
 
 Test-case: output
 Description: Test mapping type-descriptor being covariant in the types of their members.
-Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
-        anydata-type-descriptor, mapping-constructor-expr, int-literal
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
+        any-type-descriptor, mapping-constructor-expr, int-literal
 
 public function main() {
-    map<byte> a = {a: 1, b: 2};
+    map<int> a = {a: 1, b: 2};
     testMap(a);
 
-    map<int> b = a;
+    map<int?> b = a;
     testMap(b);
 }
 
-function testMap(map<anydata> m) {
+function testMap(map<any> m) {
     io:println(m); // @output {"a":1,"b":2}
                    // @output {"a":1,"b":2} 
 }
 
 Test-case: output
 Description: Test mapping type-descriptor being covariant in the types of their members, at runtime.
-Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
-        anydata-type-descriptor, mapping-constructor-expr, int-literal, string-literal, is-expr
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
+        any-type-descriptor, mapping-constructor-expr, int-literal, string-literal, nil-literal, is-expr
 
 public function main() {
-    map<byte> a = {a: 1, b: 2};
+    map<int> a = {a: 1, b: 2};
     testMap(a);
 
-    map<int> b = a;
+    map<int?> b = a;
     testMap(b);
 
-    map<int> c = {x: 1, y: 2, z: 3};
+    map<int?> c = {x: 1, y: 2, z: ()};
     testMap(c);
 
-    map<anydata> d = {a: 1, b: "hello world"};
+    map<any> d = {a: 1, b: "hello world"};
     testMap(d);
 
     testMap({a: 1, b: 2});
 }
 
-function testMap(map<anydata> m) {
-    io:println(m is map<int>); // @output true
-                               // @output true
-                               // @output true
-                               // @output false
-                               // @output false
+function testMap(map<any> m) {
+    io:println(m is map<int?>); // @output true
+                                // @output true
+                                // @output true
+                                // @output false
+                                // @output false
 }
 
 Test-case: error
 Description: Test mapping type-descriptor being covariant in the types of their members, via incompatible assignments.
-Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
         string-type-descriptor, mapping-constructor-expr
 
 public function main() {
-    map<int> a = {};
-    testMap(a); // @error map of int is not a subtype of map of byte
+    map<int?> a = {};
+    testMap(a); // @error map of int? is not a subtype of map of int
 
-    map<string> b = a; // @error map of int is not a subtype of map of string
+    map<string> b = a; // @error map of int? is not a subtype of map of string
 }
 
-function testMap(map<byte> m) {
+function testMap(map<int> m) {
 }
 
 Test-case: panic
 Description: Test inherent type violation of a map.
-Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, anydata-type-descriptor, 
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, any-type-descriptor, 
         mapping-constructor-expr, int-literal, string-literal, assignment-stmt, member-access-lvexpr, lvexpr
 
 public function main() {
@@ -190,22 +190,22 @@ public function main() {
     testMap(a, "hello");
 }
 
-function testMap(map<anydata> m, anydata value) {
-    m["k"] = value; // @panic cannot insert a string value as a field of a map<int>
+function testMap(map<any> m, any v) {
+    m["k"] = v; // @panic cannot insert a string value as a field of a map<int>
 }
 
 Test-case: panic
 Description: Test inherent type violation of a map with a value that looks like the constraint.
-Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, anydata-type-descriptor, 
-        byte-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, any-type-descriptor, 
+        optional-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
         member-access-lvexpr, lvexpr
 
 public function main() {
-    map<map<byte>> a = {x: {a: 1, b: 2}};
-    map<int> b = {a: 0, b: 255};
+    map<map<int>> a = {x: {a: 1, b: 2}};
+    map<int?> b = {a: 0, b: 255};
     testMap(a, b); 
 }
 
-function testMap(map<anydata> m, anydata value) {
-    m["k"] = value; // @panic cannot insert a map<int> value as a field of a map<map<byte>>
+function testMap(map<any> m, any v) {
+    m["k"] = v; // @panic cannot insert a map<int?> value as a field of a map<map<int>>
 }

--- a/conformance/lang/values-types-and-variables/map_types.balt
+++ b/conformance/lang/values-types-and-variables/map_types.balt
@@ -111,11 +111,75 @@ public function main() {
 Test-case: error
 Description: Test the iteration completion value of a map being nil via incompatible assignments.
 Labels: map-type-descriptor, mapping-type-descriptor, record-type-descriptor, int-type-descriptor, 
-        error-type-descriptor, mapping-constructor-expr, lang.map
+        error-type-descriptor, union-type-descriptor, mapping-constructor-expr, lang.map
 
 public function main() {
     map<int> a = {};    
     record {| int value; |}|error next = a.iterator().next(); // @error completion type for map iteration is nil
+}
+
+Test-case: output
+Description: Test no two fields in a map sharing the same key.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr, int-literal
+        string-literal, assignment-stmt, member-access-lvexpr, lvexpr
+
+public function main() {
+    map<int> a = {x: 1, y: 2};
+    testMap(a);
+
+    a["x"] = 3;
+    testMap(a);
+}
+
+function testMap(map<any> m) {
+    io:println(m); // @output {"x":1,"y":2}
+                   // @output {"x":3,"y":2}
+}
+
+Test-case: error
+Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
+             to assign to and remove such fields.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
+        member-access-lvexpr, lvexpr, lang.map
+
+public function main() {
+    map<int> & readonly a = {x: 1, y: 2};
+
+    int b = a.remove("x"); // @error cannot remove a field with its read-only bit on
+
+    a["z"] = 3; // @error cannot assign to a field with its read-only bit on
+}
+
+Test-case: panic
+Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
+             to assign to such fields at runtime.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
+        member-access-lvexpr, lvexpr
+
+public function main() {
+    map<int> & readonly a = {x: 1, y: 2};
+    testAssignment(a);
+}
+
+function testAssignment(map<int> m) {
+    m["z"] = 3; // @panic cannot assign to a field with its read-only bit on
+}
+
+Test-case: panic
+Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
+             to remove such fields at runtime.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal, lang.map
+
+public function main() {
+    map<int> & readonly a = {x: 1, y: 2};
+    testRemoval(a);
+}
+
+function testRemoval(map<int> m) {
+    int b = m.remove("x"); // @panic cannot remove a field with its read-only bit on
 }
 
 Test-case: output
@@ -208,4 +272,47 @@ public function main() {
 
 function testMap(map<any> m, any v) {
     m["k"] = v; // @panic cannot insert a map<int?> value as a field of a map<map<int>>
+}
+
+Test-case: output
+Description: Test immutability being deep for maps.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal, is-expr
+
+public function main() {
+    map<map<int>> & readonly a = {a: {x: 1, y: 2}, b: {}};
+    testMap(a);
+}
+
+function testMap(map<map<int>> m) {
+    io:println(m is map<map<int>> & readonly); // @output true
+    io:println(m["a"] is map<int> & readonly); // @output true
+}
+
+Test-case: error
+Description: Test immutability maps not allowing mutable members.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal
+
+public function main() {
+    map<int> a = {a: 1};
+    map<map<int>> & readonly b = {x: a}; // @error an immutable map cannot contain a mutable value as a member
+}
+
+Test-case: output
+Description: Test an immutable map belonging to a type if and only if the type contains the shape of the value.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
+        intersection-type-descriptor, mapping-constructor-expr, int-literal, nil-literal, is-expr
+
+public function main() {
+    map<int?> & readonly a = {a: 1, b: ()};
+    testMap(a);
+
+    map<int?> & readonly b = {a: 1, b: 2};
+    testMap(b);
+}
+
+function testMap(map<int?> m) {
+    io:println(m is map<int>); // @output false
+                               // @output true
 }

--- a/conformance/lang/values-types-and-variables/map_types.balt
+++ b/conformance/lang/values-types-and-variables/map_types.balt
@@ -1,0 +1,211 @@
+Test-case: output
+Description: Test map type descriptor.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr
+
+public function main() {
+    map<int> a = {};
+    testMap(a);
+
+    map<int> b;
+}
+
+function testMap(map<int> m) {
+    io:println(m); // @output {}
+}
+
+Test-case: error
+Description: Test a map type descriptor without the type-parameter.
+Labels: map-type-descriptor, mapping-type-descriptor
+
+public function main() {
+    map a; // @error a map type descriptor must have a type-parameter
+}
+
+Test-case: error
+Description: Test a map type descriptor with an incomplete type-parameter.
+Labels: map-type-descriptor, mapping-type-descriptor
+
+public function main() {
+    map<> a; // @error a type-parameter must have a type-descriptor
+}
+
+Test-case: output
+Description: Test a type map<T> containing a mapping shape m if every field shape in m has a value shape that is in T.
+Labels: map-type-descriptor, mapping-type-descriptor, string-type-descriptor, mapping-constructor-expr, string-literal
+
+public function main() {
+    map<string> a = {a: "1"};
+    testMap(a);
+
+    testMap({a: "hello", b: ""});
+}
+
+function testMap(map<string> m) {
+    io:println(m); // @output {"a":"1"}
+                   // @output {"a":"hello","b":""}
+}
+
+Test-case: error
+Description: Test a type map<T> not containing a mapping shape m if a field shape in m has a value shape 
+             that is not in T.
+Labels: map-type-descriptor, mapping-type-descriptor, mapping-constructor-expr, int-type-descriptor, 
+        int-literal, string-literal
+
+public function main() {
+    map<int> a = {a: 1, b: "hello"}; // @error an int map cannot contain string values
+
+    testMap({
+        a: "hello", // @error an int map cannot contain string values 
+        b: "world", // @error an int map cannot contain string values
+        c: 0
+    });
+}
+
+function testMap(map<int> m) {
+}
+
+Test-case: output
+Description: Test the type of the values in the iteration sequence of a value belonging to map<T> being T and the 
+             iteration completion value being nil.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr, int-literal, 
+        foreach-stmt
+
+public function main() {
+    map<int> a = {a: 1, b: 2};
+
+    foreach int i in a {
+        testNextValue(i);
+    }
+
+    map<int> b = {a: 0};
+    foreach int i in b {
+        testNextValue(i);
+    }
+
+    map<int> c = {};
+    foreach int i in c {
+        testNextValue(i);
+    }
+}
+
+function testNextValue(int i) {
+    io:println(i); // @output 1
+                   // @output 2
+                   // @output 0 
+}
+
+Test-case: error
+Description: Test the type of the values in the iteration sequence of a value belonging to map<T> being T 
+             via incompatible assignments.
+Labels: map-type-descriptor, mapping-type-descriptor, string-type-descriptor, int-type-descriptor, 
+        mapping-constructor-expr, int-literal, foreach-stmt
+
+public function main() {
+    map<int> a = {a: 1, b: 2};
+
+    foreach string s in a { // @error value in the iteration sequence should be int
+
+    }
+}
+
+Test-case: error
+Description: Test the iteration completion value of a map being nil via incompatible assignments.
+Labels: map-type-descriptor, mapping-type-descriptor, record-type-descriptor, int-type-descriptor, 
+        error-type-descriptor, mapping-constructor-expr, lang.map
+
+public function main() {
+    map<int> a = {};    
+    record {| int value; |}|error next = a.iterator().next(); // @error completion type for map iteration is nil
+}
+
+Test-case: output
+Description: Test mapping type-descriptor being covariant in the types of their members.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
+        anydata-type-descriptor, mapping-constructor-expr, int-literal
+
+public function main() {
+    map<byte> a = {a: 1, b: 2};
+    testMap(a);
+
+    map<int> b = a;
+    testMap(b);
+}
+
+function testMap(map<anydata> m) {
+    io:println(m); // @output {"a":1,"b":2}
+                   // @output {"a":1,"b":2} 
+}
+
+Test-case: output
+Description: Test mapping type-descriptor being covariant in the types of their members, at runtime.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
+        anydata-type-descriptor, mapping-constructor-expr, int-literal, string-literal, is-expr
+
+public function main() {
+    map<byte> a = {a: 1, b: 2};
+    testMap(a);
+
+    map<int> b = a;
+    testMap(b);
+
+    map<int> c = {x: 1, y: 2, z: 3};
+    testMap(c);
+
+    map<anydata> d = {a: 1, b: "hello world"};
+    testMap(d);
+
+    testMap({a: 1, b: 2});
+}
+
+function testMap(map<anydata> m) {
+    io:println(m is map<int>); // @output true
+                               // @output true
+                               // @output true
+                               // @output false
+                               // @output false
+}
+
+Test-case: error
+Description: Test mapping type-descriptor being covariant in the types of their members, via incompatible assignments.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, byte-type-descriptor, 
+        string-type-descriptor, mapping-constructor-expr
+
+public function main() {
+    map<int> a = {};
+    testMap(a); // @error map of int is not a subtype of map of byte
+
+    map<string> b = a; // @error map of int is not a subtype of map of string
+}
+
+function testMap(map<byte> m) {
+}
+
+Test-case: panic
+Description: Test inherent type violation of a map.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, anydata-type-descriptor, 
+        mapping-constructor-expr, int-literal, string-literal, assignment-stmt, member-access-lvexpr, lvexpr
+
+public function main() {
+    map<int> a = {a: 1, b: 2};
+    testMap(a, "hello");
+}
+
+function testMap(map<anydata> m, anydata value) {
+    m["k"] = value; // @panic cannot insert a string value as a field of a map<int>
+}
+
+Test-case: panic
+Description: Test inherent type violation of a map with a value that looks like the constraint.
+Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, anydata-type-descriptor, 
+        byte-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
+        member-access-lvexpr, lvexpr
+
+public function main() {
+    map<map<byte>> a = {x: {a: 1, b: 2}};
+    map<int> b = {a: 0, b: 255};
+    testMap(a, b); 
+}
+
+function testMap(map<anydata> m, anydata value) {
+    m["k"] = value; // @panic cannot insert a map<int> value as a field of a map<map<byte>>
+}

--- a/conformance/lang/values-types-and-variables/map_types.balt
+++ b/conformance/lang/values-types-and-variables/map_types.balt
@@ -1,4 +1,4 @@
-Test-case: output
+Test-Case: output
 Description: Test map type descriptor.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr
 
@@ -13,7 +13,7 @@ function testMap(map<int> m) {
     io:println(m); // @output {}
 }
 
-Test-case: error
+Test-Case: error
 Description: Test a map type descriptor without the type-parameter.
 Labels: map-type-descriptor, mapping-type-descriptor
 
@@ -21,7 +21,7 @@ public function main() {
     map a; // @error a map type descriptor must have a type-parameter
 }
 
-Test-case: error
+Test-Case: error
 Description: Test a map type descriptor with an incomplete type-parameter.
 Labels: map-type-descriptor, mapping-type-descriptor
 
@@ -29,7 +29,7 @@ public function main() {
     map<> a; // @error a type-parameter must have a type-descriptor
 }
 
-Test-case: output
+Test-Case: output
 Description: Test a type map<T> containing a mapping shape m if every field shape in m has a value shape that is in T.
 Labels: map-type-descriptor, mapping-type-descriptor, string-type-descriptor, mapping-constructor-expr, string-literal
 
@@ -45,7 +45,7 @@ function testMap(map<string> m) {
                    // @output {"a":"hello","b":""}
 }
 
-Test-case: error
+Test-Case: error
 Description: Test a type map<T> not containing a mapping shape m if a field shape in m has a value shape 
              that is not in T.
 Labels: map-type-descriptor, mapping-type-descriptor, mapping-constructor-expr, int-type-descriptor, 
@@ -64,7 +64,7 @@ public function main() {
 function testMap(map<int> m) {
 }
 
-Test-case: output
+Test-Case: output
 Description: Test the type of the values in the iteration sequence of a value belonging to map<T> being T and the 
              iteration completion value being nil.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr, int-literal, 
@@ -94,7 +94,7 @@ function testNextValue(int i) {
                    // @output 0 
 }
 
-Test-case: error
+Test-Case: error
 Description: Test the type of the values in the iteration sequence of a value belonging to map<T> being T 
              via incompatible assignments.
 Labels: map-type-descriptor, mapping-type-descriptor, string-type-descriptor, int-type-descriptor, 
@@ -108,7 +108,7 @@ public function main() {
     }
 }
 
-Test-case: error
+Test-Case: error
 Description: Test the iteration completion value of a map being nil via incompatible assignments.
 Labels: map-type-descriptor, mapping-type-descriptor, record-type-descriptor, int-type-descriptor, 
         error-type-descriptor, union-type-descriptor, mapping-constructor-expr, lang.map
@@ -118,7 +118,7 @@ public function main() {
     record {| int value; |}|error next = a.iterator().next(); // @error completion type for map iteration is nil
 }
 
-Test-case: output
+Test-Case: output
 Description: Test no two fields in a map sharing the same key.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, mapping-constructor-expr, int-literal
         string-literal, assignment-stmt, member-access-lvexpr, lvexpr
@@ -136,7 +136,7 @@ function testMap(map<any> m) {
                    // @output {"x":3,"y":2}
 }
 
-Test-case: error
+Test-Case: error
 Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
              to assign to and remove such fields.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
@@ -151,7 +151,7 @@ public function main() {
     a["z"] = 3; // @error cannot assign to a field with its read-only bit on
 }
 
-Test-case: panic
+Test-Case: panic
 Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
              to assign to such fields at runtime.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
@@ -167,7 +167,7 @@ function testAssignment(map<int> m) {
     m["z"] = 3; // @panic cannot assign to a field with its read-only bit on
 }
 
-Test-case: panic
+Test-Case: panic
 Description: Test the read-only bit being set for a field of a map value with its read-only bit set, by attempting 
              to remove such fields at runtime.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
@@ -182,7 +182,7 @@ function testRemoval(map<int> m) {
     int b = m.remove("x"); // @panic cannot remove a field with its read-only bit on
 }
 
-Test-case: output
+Test-Case: output
 Description: Test mapping type-descriptor being covariant in the types of their members.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
         any-type-descriptor, mapping-constructor-expr, int-literal
@@ -200,7 +200,7 @@ function testMap(map<any> m) {
                    // @output {"a":1,"b":2} 
 }
 
-Test-case: output
+Test-Case: output
 Description: Test mapping type-descriptor being covariant in the types of their members, at runtime.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
         any-type-descriptor, mapping-constructor-expr, int-literal, string-literal, nil-literal, is-expr
@@ -229,7 +229,7 @@ function testMap(map<any> m) {
                                 // @output false
 }
 
-Test-case: error
+Test-Case: error
 Description: Test mapping type-descriptor being covariant in the types of their members, via incompatible assignments.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, optional-type-descriptor, 
         string-type-descriptor, mapping-constructor-expr
@@ -244,7 +244,7 @@ public function main() {
 function testMap(map<int> m) {
 }
 
-Test-case: panic
+Test-Case: panic
 Description: Test inherent type violation of a map.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, any-type-descriptor, 
         mapping-constructor-expr, int-literal, string-literal, assignment-stmt, member-access-lvexpr, lvexpr
@@ -258,7 +258,7 @@ function testMap(map<any> m, any v) {
     m["k"] = v; // @panic cannot insert a string value as a field of a map<int>
 }
 
-Test-case: panic
+Test-Case: panic
 Description: Test inherent type violation of a map with a value that looks like the constraint.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, any-type-descriptor, 
         optional-type-descriptor, mapping-constructor-expr, int-literal, string-literal, assignment-stmt, 
@@ -274,7 +274,7 @@ function testMap(map<any> m, any v) {
     m["k"] = v; // @panic cannot insert a map<int?> value as a field of a map<map<int>>
 }
 
-Test-case: output
+Test-Case: output
 Description: Test immutability being deep for maps.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
         intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal, is-expr
@@ -289,7 +289,7 @@ function testMap(map<map<int>> m) {
     io:println(m["a"] is map<int> & readonly); // @output true
 }
 
-Test-case: error
+Test-Case: error
 Description: Test immutability maps not allowing mutable members.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
         intersection-type-descriptor, mapping-constructor-expr, int-literal, string-literal
@@ -299,7 +299,7 @@ public function main() {
     map<map<int>> & readonly b = {x: a}; // @error an immutable map cannot contain a mutable value as a member
 }
 
-Test-case: output
+Test-Case: output
 Description: Test an immutable map belonging to a type if and only if the type contains the shape of the value.
 Labels: map-type-descriptor, mapping-type-descriptor, int-type-descriptor, readonly-type-descriptor, 
         intersection-type-descriptor, mapping-constructor-expr, int-literal, nil-literal, is-expr


### PR DESCRIPTION
## Purpose
Add conformance tests for maps covering [map-type-descriptor](https://ballerina.io/ballerina-spec/spec.html#section_5.4.2.1) and relevant sections of [mapping-type-descriptor](https://ballerina.io/ballerina-spec/spec.html#section_5.4.2).

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/32362.