### PR TITLE
Enable set of failing byte array literal spec conformance tests

### DIFF
--- a/conformance/lang/expressions/literals/byte_array_literal.balt
+++ b/conformance/lang/expressions/literals/byte_array_literal.balt
@@ -27,7 +27,6 @@ function init() {
 
 Test-Case: output
 Description: Test different ways of writing the same base16 byte array literal with tabs.
-Fail-Issue: ballerina-platform/ballerina-lang#32545
 Labels: byte-array-literal
 
 function init() {
@@ -40,7 +39,6 @@ function init() {
 
 Test-Case: output
 Description: Test different ways of writing the same base16 byte array literal with newlines.
-Fail-Issue: ballerina-platform/ballerina-lang#32545
 Labels: byte-array-literal
 
 function init() {
@@ -291,7 +289,6 @@ function init() {
 
 Test-Case: output
 Description: Test different ways of writing the same base64 byte array literal with tabs.
-Fail-Issue: ballerina-platform/ballerina-lang#32545
 Labels: byte-array-literal
 
 function init() {
@@ -303,7 +300,6 @@ function init() {
 
 Test-Case: output
 Description: Test different ways of writing the same base64 byte array literal with newlines.
-Fail-Issue: ballerina-platform/ballerina-lang#32545
 Labels: byte-array-literal
 
 function init() {


### PR DESCRIPTION
## Purpose
Enable tests that were disabled due to [32545](https://github.com/ballerina-platform/ballerina-lang/issues/32545). Fixed with [33356](https://github.com/ballerina-platform/ballerina-lang/pull/33356)