### PR TITLE
Update the default branch to dev

### DIFF
--- a/.github/workflows/draft_build.yml
+++ b/.github/workflows/draft_build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Sync ballerina-spec with ballerina-dev-website
         run: |
           cd ballerina-dev-website
-          git pull origin master
+          git pull origin dev
 
           git config --global user.email "ballerina-bot@ballerina.org"
           git config --global user.name "ballerina-bot"

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Sync spec in master with ballerina-dev-website
         run: |
           cd ballerina-dev-website
-          git pull origin master
+          git pull origin dev
 
           git config --global user.email "ballerina-bot@ballerina.org"
           git config --global user.name "ballerina-bot"


### PR DESCRIPTION
## Purpose
ballerina-dev-website repo's default branch has changed to `dev` recently. Therefore, the workflow was failing as it was written considering `master` as the default branch.

This PR is to update the workflow accordingly. 