### PR TITLE
Fix the path issue in build_draft workflow

### DIFF
--- a/.github/workflows/draft_build.yml
+++ b/.github/workflows/draft_build.yml
@@ -54,18 +54,13 @@ jobs:
           git checkout $GITHUB_REF -b tmp
           cd lang
           make all
+          mv build/spec.html build/index.html
           
       - name: Copy new spec to ballerina-dev-website
-        run: |
-          cp -r lang/build/lib/ ballerina-dev-website/spec/lang/draft/$NEW_FOLDER
-          cp -r lang/build/style/ ballerina-dev-website/spec/lang/draft/$NEW_FOLDER
-          cp -r lang/build/spec.html ballerina-dev-website/spec/lang/draft/$NEW_FOLDER/index.html
+        run: cp -r lang/build/ ballerina-dev-website/spec/lang/draft/$NEW_FOLDER
 
       - name: Copy new spec to ballerina-prod-website
-        run: |
-          cp -r lang/build/lib/ ballerina-platform.github.io/spec/lang/draft/$NEW_FOLDER
-          cp -r lang/build/style/ ballerina-platform.github.io/spec/lang/draft/$NEW_FOLDER
-          cp -r lang/build/spec.html ballerina-platform.github.io/spec/lang/draft/$NEW_FOLDER/index.html
+        run: cp -r lang/build/ ballerina-platform.github.io/spec/lang/draft/$NEW_FOLDER
 
       - name: Update the list of draft specs in ballerina-dev-website
         run: python3 .github/scripts/append.py ballerina-dev-website/_data/draft_spec.json $NEW_FOLDER


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix the below failure.

https://github.com/ballerina-platform/ballerina-spec/actions/runs/1685880137

## Approach
The failure is because make all output no longer have lib directory. However, this was not impacting the master_build workflow because it was copying everything inside build directory at once.

I have update the draft_build workflow to do the same.