### PR TITLE
make error:Cloneable public

### DIFF
--- a/lang/lib/error.bal
+++ b/lang/lib/error.bal
@@ -18,7 +18,7 @@
 # Type for value that can be cloned.
 # This is the same as in lang.value, but is copied here to avoid a dependency.
 
-type Cloneable readonly|xml|Cloneable[]|map<Cloneable>|table<map<Cloneable>>;
+public type Cloneable readonly|xml|Cloneable[]|map<Cloneable>|table<map<Cloneable>>;
 
 # The type to which error detail records must belong.
 public type Detail record {|


### PR DESCRIPTION
## Purpose
Issue https://github.com/ballerina-platform/ballerina-spec/issues/820 propose to make the type `error:Cloneable` a public value. Since error module is a pre defined module type can be used without any import statements.
This is related to https://github.com/ballerina-platform/ballerina-spec/issues/820 will be implemented via issue https://github.com/ballerina-platform/ballerina-lang/issues/35182
