### PR TITLE
Add spec conformance tests for object-constructor-expr fields and methods

### DIFF
--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -540,8 +540,7 @@ Labels: array-type, int, isolated-object, list-constructor-expr, method-defn, ob
 function errorFunction() {
     int[] arr = [];
     var _ = isolated object {
-        int[] val = arr; // @error invalid non-private mutable field in an isolated object
-                         // @error invalid initial value expression: expected an isolated expression
+        int[] val = arr; // @error invalid non-private mutable field in an isolated object and invalid initial value expression: expected an isolated expression
         function init() {
         }
     };

--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -35,8 +35,9 @@ function init() {
 
 Test-Case: output
 Description: Test declaration and initialization of a field of an object with meta data.
-Labels: annotation, annotation-decl, field-access-expr, module-type-defn, object-constructor-expr, object-field,
-        record-type, var
+Fail-Issue: ballerina-platform/ballerina-lang#34859
+Labels: annotation-decl, annotation, field-access-expr, int, object-field, module-type-defn, object-constructor-expr,
+        record-type, string, type-cast-expr, typeof-expr, var
 
 type Annot record {
     string a;
@@ -53,7 +54,9 @@ function init() {
         }
         int val = 10;
     };
-    io:println(obj.val); // @output 10
+
+    Annot annot = <Annot>(typeof obj.val).@v1;
+    io:println(annot.a); // @output v1
 }
 
 Test-Case: output

--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -78,7 +78,6 @@ function init() {
 Test-Case: output
 Description: Test initializing a field when the field does not specify a field-initializer in init method.
 Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
-Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
 
 function init() {
     var obj = object {
@@ -93,7 +92,6 @@ function init() {
 
 Test-Case: output
 Description: Test initializing a final field when the field does not specify a field-initializer in init method.
-Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
 Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
 
 function init() {

--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -1,6 +1,6 @@
 Test-Case: output
 Description: Test declaration and initialization of a field of an object.
-Labels: field-access-expr, module-type-defn, object-constructor-expr, object-field, object-type
+Labels: field-access-expr, module-type-defn, object-constructor-expr, object-type
 
 type ObjectType object {
     int val;
@@ -15,7 +15,7 @@ function init() {
 
 Test-Case: output
 Description: Test declaration and initialization of a field of an object with visibility qualifier.
-Labels: field-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, method-call-expr, object-constructor-expr, var
 
 function init() {
     var obj = object {
@@ -36,7 +36,7 @@ function init() {
 Test-Case: output
 Description: Test declaration and initialization of a field of an object with meta data.
 Fail-Issue: ballerina-platform/ballerina-lang#34859
-Labels: annotation-decl, annotation, field-access-expr, int, object-field, module-type-defn, object-constructor-expr,
+Labels: annotation-decl, annotation, field-access-expr, int, module-type-defn, object-constructor-expr,
         record-type, string, type-cast-expr, typeof-expr, var
 
 type Annot record {
@@ -61,7 +61,7 @@ function init() {
 
 Test-Case: output
 Description: Test declaration and initialization of a final field of an object.
-Labels: field-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, method-call-expr, object-constructor-expr, var
 
 function init() {
     var obj = object {
@@ -77,7 +77,7 @@ function init() {
 
 Test-Case: output
 Description: Test initializing a field when the field does not specify a field-initializer in init method.
-Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, object-constructor-expr, var
 
 function init() {
     var obj = object {
@@ -92,7 +92,7 @@ function init() {
 
 Test-Case: output
 Description: Test initializing a final field when the field does not specify a field-initializer in init method.
-Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, object-constructor-expr, var
 
 function init() {
     var obj = object {
@@ -108,7 +108,7 @@ function init() {
 Test-Case: error
 Description: Test behaviour when a field does not specify a field-initializer and there is no init method
              initializing the field.
-Labels: object-constructor-expr, object-field, var
+Labels: object-constructor-expr, var
 
 function errorFunction() {
     var _ = object {
@@ -120,7 +120,7 @@ function errorFunction() {
 Test-Case: error
 Description: Test behaviour of assigning a value to a final field which does not specify a field-initializer and there
              is no init method initializing the field.
-Labels: object-constructor-expr, object-field, var
+Labels: object-constructor-expr, var
 
 function errorFunction() {
     var _ = object {
@@ -136,7 +136,7 @@ Test-Case: output
 Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
              present and not declared as isolated.
 Labels: array-type, field-access-expr, int, intersection-type, list-constructor-expr, module-init-var-decl,
-        object-constructor-expr, object-field, readonly-type, var
+        object-constructor-expr, readonly-type, var
 
 final int[] & readonly intArr = [10];
 final int intVal = 10;
@@ -154,7 +154,7 @@ Test-Case: output
 Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
              present and declared as isolated.
 Labels: field-access-expr, function-call-expr, int, intersection-type, isolated-function, module-init-var-decl,
-        object-constructor-expr, object-field, var
+        object-constructor-expr, var
 
 function init() {
     var obj = object {
@@ -170,7 +170,7 @@ isolated function getIntVal() returns int {
 Test-Case: error
 Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
              present and not declared as isolated.
-Labels: function-call-expr, int, module-init-var-decl, object-constructor-expr, object-field, var
+Labels: function-call-expr, int, module-init-var-decl, object-constructor-expr, var
 
 int intVal = 10;
 
@@ -188,8 +188,7 @@ function getIntVal() returns int {
 Test-Case: output
 Description: Test field-initializer not required to meet the requirements for an isolated expression when the
              init method is present.
-Labels: field-access-expr, function-call-expr, int, method-defn, module-init-var-decl, object-constructor-expr,
-        object-field, var
+Labels: field-access-expr, function-call-expr, int, module-init-var-decl, object-constructor-expr, var
 
 int intVal = 10;
 
@@ -214,7 +213,7 @@ Description: Test whether the contextually expected type for a field-initializer
              and the type specified in the type-descriptor of the object-field when the object-constructor-expr
              is implicitly read-only.
 Labels: array-type, field-access-expr, function-call-expr, int, intersection-type, is-expr, list-constructor-expr,
-        method-defn, module-type-defn, object-constructor-expr, object-field, object-type, readonly-type
+        module-type-defn, object-constructor-expr, object-type, readonly-type
 
 type ObjectType readonly & object {
     int[] val;
@@ -239,8 +238,8 @@ Test-Case: error
 Description: Test whether the contextually expected type for a field-initializer is the intersection of readonly
              and the type specified in the type-descriptor of the object-field when the object-constructor-expr
              is implicitly read-only.
-Labels: array-type, field-access-expr, function-call-expr, int, intersection-type, list-constructor-expr, method-defn,
-        module-type-defn, object-constructor-expr, object-field, object-type, readonly-type
+Labels: array-type, field-access-expr, function-call-expr, int, intersection-type, list-constructor-expr, module-type-defn,
+        object-constructor-expr, object-type, readonly-type
 
 type ObjectType readonly & object {
     int[] val;
@@ -262,8 +261,7 @@ function getIntVal() returns int[] {
 Test-Case: error
 Description: Test whether the field is assigned to exactly once, either by its initializer or in the init method
              when final is present.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-defn, object-constructor-expr, object-field,
-        object-type, var
+Labels: array-type, field-access-expr, int, list-constructor-expr, object-constructor-expr, object-type, var
 
 function errorFunction() {
     var _ = object {
@@ -278,8 +276,7 @@ function errorFunction() {
 Test-Case: error
 Description: Test whether the field is assigned to exactly once, either by its initializer or in the init method
              when final is present.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-defn, object-constructor-expr, object-field,
-        object-type, var
+Labels: array-type, field-access-expr, int, list-constructor-expr, object-constructor-expr, object-type, var
 
 function errorFunction() {
     var _ = object {
@@ -298,8 +295,8 @@ function errorFunction() {
 Test-Case: output
 Description: Test object-constructor-expr constructing an object with its read-only bit set if every object-field
              is declared as final and has a type-descriptor that is a subtype of readonly.
-Labels: any, array-type, int, intersection-type, is-expr, list-constructor-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr, var
+Labels: any, array-type, int, intersection-type, is-expr, list-constructor-expr, module-type-defn,
+        object-constructor-expr, object-type, readonly-type, type-cast-expr, var
 
 type ObjectType object {
     int[] val;
@@ -335,8 +332,8 @@ function init() {
 Test-Case: error
 Description: Test object-constructor-expr constructing an object with its read-only bit set if every object-field
              is declared as final and has a type-descriptor that is a subtype of readonly.
-Labels: array-type, int, intersection-type, list-constructor-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type, readonly-type, var
+Labels: array-type, int, intersection-type, list-constructor-expr, module-type-defn, object-constructor-expr,
+        object-type, readonly-type, var
 
 type ObjectType object {
     int[] val;
@@ -358,7 +355,7 @@ Test-Case: output
 Description: Test isolatedness of object field if it is declared as final and has a type-descriptor that is a subtype of
              readonly.
 Labels: array-type, field-access-expr, int, intersection-type, list-constructor-expr, lock-stmt, module-init-var-decl,
-        object-constructor-expr, object-field, readonly-type, var
+        object-constructor-expr, readonly-type, var
 
 var obj = object {
     final int[] & readonly val = [1, 2];
@@ -375,7 +372,7 @@ function init() {
 Test-Case: output
 Description: Test isolatedness of object field if its type-descriptor is isolated object {}.
 Labels: any, array-type, field-access-expr, int, is-expr, isolated-object, list-constructor-expr, lock-stmt, member-access-expr,
-        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, object-type, var
+        method-call-expr, module-init-var-decl, object-constructor-expr, object-type, var
 
 var obj = object {
     isolated object {
@@ -396,7 +393,7 @@ function init() {
 Test-Case: output
 Description: Test isolatedness of object field if the object-constructor-expr is implicitly read-only.
 Labels: any, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr, lock-stmt,
-        member-access-expr, method-call-expr, method-defn, module-type-defn, object-constructor-expr, object-field,
+        member-access-expr, method-call-expr, module-type-defn, object-constructor-expr, 
         object-type, readonly-type
 
 type ObjectType readonly & object {
@@ -419,7 +416,7 @@ Test-Case: error
 Description: Test non-isolatedness of object field if it is not final, not have a type-descriptor that
              is a subtype of readonly or isolated object {}, nor implicitly read-only.
 Labels: array-type, field-access-expr, int, list-constructor-expr, module-init-var-decl, object-constructor-expr,
-        object-field, var
+        var
 
 var obj = object {
     int[] val = [23];
@@ -430,7 +427,7 @@ isolated int[][] b = [[12], obj.val]; // @error invalid initial value expression
 Test-Case: output
 Description: Test whether an object-constructor-expr is implicitly isolated if it is implicitly readonly.
 Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr, module-type-defn,
-        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr
+        object-constructor-expr, object-type, readonly-type, type-cast-expr
 
 type ObjectType readonly & object {
     int[] val;
@@ -445,7 +442,7 @@ function init() {
 Test-Case: output
 Description: Test object-constructor-expr that is implicitly isolated constructing an object with its isolated bit set.
 Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr, module-type-defn,
-        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr
+        object-constructor-expr, object-type, readonly-type, type-cast-expr
 
 type ObjectType readonly & object {
     int[] val;
@@ -462,7 +459,7 @@ function init() {
 Test-Case: output
 Description: Test whether an object-constructor-expr is implicitly isolated if every object field is isolated.
 Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr,
-        object-constructor-expr, object-field, readonly-type, type-cast-expr
+        object-constructor-expr, readonly-type, type-cast-expr
 
 function init() {
     io:println(<any>object {
@@ -474,7 +471,7 @@ function init() {
 Test-Case: output
 Description: Test object-constructor-expr that is implicitly isolated constructing an object with its isolated bit set.
 Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr,
-        object-constructor-expr, object-field, readonly-type, type-cast-expr, var
+        object-constructor-expr, readonly-type, type-cast-expr, var
 
 function init() {
     var obj = object {
@@ -489,7 +486,7 @@ Test-Case: output
 Description: Test the static type of the object-constructor-expr being intersected with isolated object {} when the
              object-constructor-expr is implicitly isolated.
 Labels: array-type, field-access-expr, int, intersection-type, isolated-object, list-constructor-expr,
-        object-constructor-expr, object-field, object-type, readonly-type
+        object-constructor-expr, object-type, readonly-type
 
 function init() {
     isolated object {
@@ -506,7 +503,7 @@ function init() {
 Test-Case: error
 Description: Test invalid static type of the object-constructor-expr intersected with isolated object {} when the
              object-constructor-expr is not implicitly isolated.
-Labels: array-type, int, isolated-object, list-constructor-expr, object-constructor-expr, object-field, object-type
+Labels: array-type, int, isolated-object, list-constructor-expr, object-constructor-expr, object-type
 
 function errorFunction() {
     isolated object {} _ = object { // @error incompatible types, expected 'isolated object { }'
@@ -519,7 +516,7 @@ Test-Case: output
 Description: Test every field-initializer being an isolated expression and any field that is not isolated being
              declared as private when the object-constructor-expr is explicitly isolated.
 Labels: array-type, function-call-expr, int, intersection-type, isolated-function, isolated-object,
-        list-constructor-expr, object-constructor-expr, object-field, readonly-type, var
+        list-constructor-expr, object-constructor-expr, readonly-type, var
 
 function init() {
     var _ = isolated object {
@@ -535,7 +532,7 @@ isolated function getIntArr() returns int[] & readonly {
 Test-Case: error
 Description: Test field-initializer not being an isolated expression and any field that is not isolated not being
              declared as private when the object-constructor-expr is explicitly isolated.
-Labels: array-type, int, isolated-object, list-constructor-expr, method-defn, object-constructor-expr, object-field, var
+Labels: array-type, int, isolated-object, list-constructor-expr, object-constructor-expr, var
 
 function errorFunction() {
     int[] arr = [];

--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -1,0 +1,471 @@
+Test-Case: output
+Description: Test declaration and initialization of a field of an object.
+Labels: field-access-expr, module-type-defn, object-constructor-expr, object-field, object-type
+
+type ObjectType object {
+    int val;
+};
+
+function init() {
+    ObjectType obj = object {
+        int val = 10;
+    };
+    io:println(obj.val); // @output 10
+}
+
+Test-Case: output
+Description: Test declaration and initialization of a field of an object with visibility qualifier.
+Labels: field-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj = object {
+        private int val = 10;
+
+        function getVal() returns int {
+            return self.val;
+        }
+    };
+    io:println(obj.getVal()); // @output 10
+
+    var obj2 = object {
+        public  int val = 10;
+    };
+    io:println(obj2.val); // @output 10
+}
+
+Test-Case: output
+Description: Test declaration and initialization of a field of an object with meta data.
+Labels: annotation, annotation-decl, field-access-expr, module-type-defn, object-constructor-expr, object-field,
+        record-type, var
+
+type Annot record {
+    string a;
+};
+
+annotation Annot v1 on object field;
+
+function init() {
+    var obj = object {
+        # This is a document.
+        # It is for an object field.
+        @v1 {
+            a: "v1"
+        }
+        int val = 10;
+    };
+    io:println(obj.val); // @output 10
+}
+
+Test-Case: output
+Description: Test availability of an init method initializing the field when a field does not specify a
+             field-initializer.
+Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj = object {
+        int val;
+
+        function init() {
+            self.val = 10;
+        }
+    };
+    io:println(obj.val); // @output 10
+}
+
+Test-Case: error
+Description: Test behaviour when a field does not specify a field-initializer and there is no init method
+             initializing the field.
+Labels: object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var _ = object {
+        int val; // @error uninitialized field
+    };
+}
+
+Test-Case: output
+Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
+             present and not declared as isolated.
+Labels: field-access-expr, function-call-expr, int, intersection-type, isolated-function, module-init-var-decl,
+        object-constructor-expr, object-field, readonly-type, var
+
+final int & readonly intVal = 10;
+
+function init() {
+    var obj = object {
+        int val = getIntVal();
+        int val2 = intVal;
+    };
+    io:println(obj.val); // @output 10
+    io:println(obj.val2); // @output 10
+}
+
+isolated function getIntVal() returns int {
+    return 10;
+}
+
+Test-Case: error
+Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
+             present and not declared as isolated.
+Labels: function-call-expr, int, module-init-var-decl, object-constructor-expr, object-field, var
+
+int intVal = 10;
+
+function errorFunction() {
+    var _ = object {
+        int val = intVal; // @error invalid access of mutable storage in the initializer
+        int val2 = getIntVal(); // @error invalid invocation of a non-isolated function in the initializer
+    };
+}
+
+function getIntVal() returns int {
+    return 10;
+}
+
+Test-Case: output
+Description: Test field-initializer not required meeting the requirements for an isolated expression when the
+             init method is present.
+Labels: field-access-expr, function-call-expr, int, method-defn, module-init-var-decl, object-constructor-expr,
+        object-field, var
+
+int intVal = 10;
+
+function init() {
+    var obj = object {
+        int val = getIntVal();
+        int val2 = intVal;
+
+        function init() {
+        }
+    };
+    io:println(obj.val); // @output 10
+    io:println(obj.val2); // @output 10
+}
+
+function getIntVal() returns int {
+    return 10;
+}
+
+Test-Case: output
+Description: Test whether the contextually expected type for a field-initializer is the intersection of readonly
+             and the type specified in the type-descriptor of the object-field when the object-constructor-expr
+             is implicitly read-only.
+Labels: array-type, field-access-expr, function-call-expr, int, intersection-type, is-expr, list-constructor-expr,
+        method-defn, module-type-defn, object-constructor-expr, object-field, object-type, readonly-type
+
+type ObjectType readonly & object {
+    int[] val;
+};
+
+function init() {
+    ObjectType obj = object {
+        int[] val = getIntVal();
+
+        function init() {
+        }
+    };
+    io:println(<any>obj.val is int[] & readonly); // @output true
+    io:println(obj.val); // @output [1,2]
+}
+
+function getIntVal() returns int[] & readonly {
+    return [1, 2];
+}
+
+Test-Case: error
+Description: Test whether the contextually expected type for a field-initializer is the intersection of readonly
+             and the type specified in the type-descriptor of the object-field when the object-constructor-expr
+             is implicitly read-only.
+Labels: array-type, field-access-expr, function-call-expr, int, intersection-type, list-constructor-expr, method-defn,
+        module-type-defn, object-constructor-expr, object-field, object-type, readonly-type
+
+type ObjectType readonly & object {
+    int[] val;
+};
+
+function errorFunction() {
+    ObjectType _ = object {
+        int[] val = getIntVal(); // @error expected 'int[] & readonly', found 'int[]'
+
+        function init() {
+        }
+    };
+}
+
+function getIntVal() returns int[] {
+    return [1, 2];
+}
+
+Test-Case: error
+Description: Test whether the field is assigned to exactly once, either by its initializer or in the init method
+             when final is present.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-defn, object-constructor-expr, object-field,
+        object-type, var
+
+function errorFunction() {
+    var _ = object {
+        final int[] val = [];
+
+        function init() {
+            self.val = [1, 2]; // @error cannot assign a value to final variable
+        }
+    };
+}
+
+Test-Case: error
+Description: Test whether the field is assigned to exactly once, either by its initializer or in the init method
+             when final is present.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-defn, object-constructor-expr, object-field,
+        object-type, var
+
+function errorFunction() {
+    var _ = object {
+        final int[] val;
+
+        function init() {
+            self.val = [];
+        }
+
+        function setValue() {
+            self.val = [1 ,2]; // @error cannot assign a value to final variable
+        }
+    };
+}
+
+Test-Case: output
+Description: Test object-constructor-expr constructing an object with its read-only bit set if every object-field
+             is declared as final and has a type-descriptor that is a subtype of readonly.
+Labels: any, array-type, int, intersection-type, is-expr, list-constructor-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr, var
+
+type ObjectType object {
+    int[] val;
+    int val2;
+};
+
+function init() {
+    var obj = object {
+        final int[] & readonly val = [];
+        final int val2 = 10;
+
+        function init() {
+        }
+    };
+    io:println(obj is readonly); // @output true
+    io:println(obj is ObjectType & readonly); // @output true
+
+    ObjectType & readonly obj2 = obj;
+    io:println(obj2.val); // @output []
+    io:println(obj2.val2); // @output 10
+
+    var obj3 = object {
+        final int[] val = [];
+        final int val2 = 10;
+
+        function init() {
+        }
+    };
+    io:println(<any>obj3 is readonly); // @output false
+    io:println(<any>obj3 is ObjectType & readonly); // @output false
+}
+
+Test-Case: error
+Description: Test object-constructor-expr constructing an object with its read-only bit set if every object-field
+             is declared as final and has a type-descriptor that is a subtype of readonly.
+Labels: array-type, int, intersection-type, list-constructor-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type, readonly-type, var
+
+type ObjectType object {
+    int[] val;
+    int val2;
+};
+
+function errorFunction() {
+    var obj = object {
+        final int[] val = [];
+        final int val2 = 10;
+
+        function init() {
+        }
+    };
+    ObjectType & readonly _ = obj; // @error incompatible types, expected '(ObjectType & readonly)'
+}
+
+Test-Case: output
+Description: Test isolatedness of object field if it is declared as final and has a type-descriptor that is a subtype of
+             readonly.
+Labels: array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+
+function init() {
+    var obj = object {
+        final int[] & readonly val = [1, 2];
+
+        isolated function f1() returns int {
+            return self.val[1];
+        }
+    };
+    io:println(obj.f1()); // @output 2
+}
+
+Test-Case: output
+Description: Test isolatedness of object field if it is declared as final and the type-descriptor is isolated object {}.
+Labels: field-access-expr, int, isolated-function, isolated-object, method-call-expr, method-defn,
+        object-constructor-expr, object-field, object-type, var
+
+function init() {
+    var obj = object {
+        isolated object {
+            int v;
+        } val = isolated object {
+            final int v = 10;
+        };
+
+        isolated function f1() returns int {
+            return self.val.v;
+        }
+    };
+    io:println(obj.f1()); // @output 10
+}
+
+Test-Case: output
+Description: Test isolatedness of object field if the object-constructor-expr is implicitly read-only.
+Labels: array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, module-type-defn, object-constructor-expr, object-field,
+        object-type, readonly-type
+
+type ObjectType readonly & object {
+    int[] val;
+    isolated function f1() returns int;
+};
+
+function init() {
+    ObjectType obj = object {
+        int[] val = [1, 2];
+
+        isolated function f1() returns int {
+            return self.val[1];
+        }
+    };
+    io:println(obj.f1()); // @output 2
+}
+
+Test-Case: output
+Description: Test whether an object-constructor-expr is implicitly isolated if it is implicitly readonly.
+Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr, module-type-defn,
+        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr
+
+type ObjectType readonly & object {
+    int[] val;
+};
+
+function init() {
+    io:println(<any>object ObjectType {
+        int[] val = [];
+    } is isolated object {}); // @output true
+}
+
+Test-Case: output
+Description: Test object-constructor-expr that is implicitly isolated constructing an object with its isolated bit set.
+Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr, module-type-defn,
+        object-constructor-expr, object-field, object-type, readonly-type, type-cast-expr
+
+type ObjectType readonly & object {
+    int[] val;
+};
+
+function init() {
+    ObjectType obj = object {
+        int[] val = [];
+    };
+
+    io:println(<any>obj is isolated object {}); // @output true
+}
+
+Test-Case: output
+Description: Test whether an object-constructor-expr is implicitly isolated if every object field is isolated.
+Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr,
+        object-constructor-expr, object-field, readonly-type, type-cast-expr
+
+function init() {
+    io:println(<any>object {
+        final readonly & int[] val = [];
+        final int val2 = 12;
+    } is isolated object {}); // @output true
+}
+
+Test-Case: output
+Description: Test object-constructor-expr that is implicitly isolated constructing an object with its isolated bit set.
+Labels: any, array-type, int, intersection-type, is-expr, isolated-object, list-constructor-expr,
+        object-constructor-expr, object-field, readonly-type, type-cast-expr, var
+
+function init() {
+    var obj = object {
+        final readonly & int[] val = [];
+        final int val2 = 12;
+    };
+
+    io:println(<any>obj is isolated object {}); // @output true
+}
+
+Test-Case: output
+Description: Test the static type of the object-constructor-expr being intersected with isolated object {} when the
+             object-constructor-expr is implicitly isolated.
+Labels: array-type, field-access-expr, int, intersection-type, isolated-object, list-constructor-expr,
+        object-constructor-expr, object-field, object-type, readonly-type
+
+function init() {
+    isolated object {
+        int[] val;
+        int val2;
+    } obj = object {
+        final readonly & int[] val = [1, 2];
+        final int val2 = 12;
+    };
+    io:println(obj.val); // @output [1,2]
+    io:println(obj.val2); // @output 12
+}
+
+Test-Case: error
+Description: Test invalid static type of the object-constructor-expr intersected with isolated object {} when the
+             object-constructor-expr is not implicitly isolated.
+Labels: array-type, int, isolated-object, list-constructor-expr, object-constructor-expr, object-field, object-type
+
+function errorFunction() {
+    isolated object {} _ = object { // @error incompatible types, expected 'isolated object { }'
+        int[] val = [1, 2];
+        int val2 = 12;
+    };
+}
+
+Test-Case: output
+Description: Test every field-initializer being an isolated expression and any field that is not isolated being
+             declared as private when the object-constructor-expr is explicitly isolated.
+Labels: array-type, function-call-expr, int, intersection-type, isolated-function, isolated-object,
+        list-constructor-expr, object-constructor-expr, object-field, readonly-type, var
+
+function init() {
+    var _ = isolated object {
+        private int[] val = getIntArr();
+        final readonly & int[] val2 = getIntArr();
+    };
+}
+
+isolated function getIntArr() returns int[] & readonly {
+    return [1, 2];
+}
+
+Test-Case: error
+Description: Test field-initializer not being an isolated expression and any field that is not isolated not being
+             declared as private when the object-constructor-expr is explicitly isolated.
+Labels: array-type, int, isolated-object, list-constructor-expr, method-defn, object-constructor-expr, object-field, var
+
+function errorFunction() {
+    int[] arr = [];
+    var _ = isolated object {
+        int[] val = arr; // @error invalid non-private mutable field in an isolated object
+                         // @error invalid initial value expression: expected an isolated expression
+        function init() {
+        }
+    };
+}

--- a/conformance/lang/expressions/object-constructor-expr/object_fields.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_fields.balt
@@ -28,7 +28,7 @@ function init() {
     io:println(obj.getVal()); // @output 10
 
     var obj2 = object {
-        public  int val = 10;
+        public int val = 10;
     };
     io:println(obj2.val); // @output 10
 }
@@ -60,13 +60,45 @@ function init() {
 }
 
 Test-Case: output
-Description: Test availability of an init method initializing the field when a field does not specify a
-             field-initializer.
+Description: Test declaration and initialization of a final field of an object.
+Labels: field-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj = object {
+        final int val = 10;
+
+        function getVal() returns int {
+            return self.val;
+        }
+    };
+    io:println(obj.val); // @output 10
+    io:println(obj.getVal()); // @output 10
+}
+
+Test-Case: output
+Description: Test initializing a field when the field does not specify a field-initializer in init method.
+Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
 Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
 
 function init() {
     var obj = object {
         int val;
+
+        function init() {
+            self.val = 10;
+        }
+    };
+    io:println(obj.val); // @output 10
+}
+
+Test-Case: output
+Description: Test initializing a final field when the field does not specify a field-initializer in init method.
+Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj = object {
+        final int val;
 
         function init() {
             self.val = 10;
@@ -83,24 +115,54 @@ Labels: object-constructor-expr, object-field, var
 function errorFunction() {
     var _ = object {
         int val; // @error uninitialized field
+        final int val2; // @error uninitialized field
+    };
+}
+
+Test-Case: error
+Description: Test behaviour of assigning a value to a final field which does not specify a field-initializer and there
+             is no init method initializing the field.
+Labels: object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var _ = object {
+        final int val;
+
+        function setValue() {
+            self.val = 1; // @error cannot update readonly value
+        }
     };
 }
 
 Test-Case: output
 Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
              present and not declared as isolated.
-Labels: field-access-expr, function-call-expr, int, intersection-type, isolated-function, module-init-var-decl,
+Labels: array-type, field-access-expr, int, intersection-type, list-constructor-expr, module-init-var-decl,
         object-constructor-expr, object-field, readonly-type, var
 
-final int & readonly intVal = 10;
+final int[] & readonly intArr = [10];
+final int intVal = 10;
+
+function init() {
+    var obj = object {
+        int[] val = intArr;
+        int val2 = intVal;
+    };
+    io:println(obj.val); // @output [10]
+    io:println(obj.val2); // @output 10
+}
+
+Test-Case: output
+Description: Test field-initializer meeting the requirements for an isolated expression when the init method is not
+             present and declared as isolated.
+Labels: field-access-expr, function-call-expr, int, intersection-type, isolated-function, module-init-var-decl,
+        object-constructor-expr, object-field, var
 
 function init() {
     var obj = object {
         int val = getIntVal();
-        int val2 = intVal;
     };
     io:println(obj.val); // @output 10
-    io:println(obj.val2); // @output 10
 }
 
 isolated function getIntVal() returns int {
@@ -126,7 +188,7 @@ function getIntVal() returns int {
 }
 
 Test-Case: output
-Description: Test field-initializer not required meeting the requirements for an isolated expression when the
+Description: Test field-initializer not required to meet the requirements for an isolated expression when the
              init method is present.
 Labels: field-access-expr, function-call-expr, int, method-defn, module-init-var-decl, object-constructor-expr,
         object-field, var
@@ -284,7 +346,7 @@ type ObjectType object {
 };
 
 function errorFunction() {
-    var obj = object {
+    ObjectType obj = object {
         final int[] val = [];
         final int val2 = 10;
 
@@ -297,61 +359,75 @@ function errorFunction() {
 Test-Case: output
 Description: Test isolatedness of object field if it is declared as final and has a type-descriptor that is a subtype of
              readonly.
-Labels: array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+Labels: array-type, field-access-expr, int, intersection-type, list-constructor-expr, lock-stmt, module-init-var-decl,
+        object-constructor-expr, object-field, readonly-type, var
+
+var obj = object {
+    final int[] & readonly val = [1, 2];
+};
+
+isolated int[][] b = [[12], obj.val];
 
 function init() {
-    var obj = object {
-        final int[] & readonly val = [1, 2];
-
-        isolated function f1() returns int {
-            return self.val[1];
-        }
-    };
-    io:println(obj.f1()); // @output 2
+    lock {
+        io:println(b); // @output [[12],[1,2]]
+    }
 }
 
 Test-Case: output
-Description: Test isolatedness of object field if it is declared as final and the type-descriptor is isolated object {}.
-Labels: field-access-expr, int, isolated-function, isolated-object, method-call-expr, method-defn,
-        object-constructor-expr, object-field, object-type, var
+Description: Test isolatedness of object field if its type-descriptor is isolated object {}.
+Labels: any, array-type, field-access-expr, int, is-expr, isolated-object, list-constructor-expr, lock-stmt, member-access-expr,
+        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, object-type, var
+
+var obj = object {
+    isolated object {
+        int v;
+    } val = isolated object {
+        final int v = 10;
+    };
+};
+
+isolated any[][] b = [[12], [obj.val]];
 
 function init() {
-    var obj = object {
-        isolated object {
-            int v;
-        } val = isolated object {
-            final int v = 10;
-        };
-
-        isolated function f1() returns int {
-            return self.val.v;
-        }
-    };
-    io:println(obj.f1()); // @output 10
+    lock {
+        io:println(b[1][0] is isolated object{}); // @output true
+    }
 }
 
 Test-Case: output
 Description: Test isolatedness of object field if the object-constructor-expr is implicitly read-only.
-Labels: array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+Labels: any, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr, lock-stmt,
         member-access-expr, method-call-expr, method-defn, module-type-defn, object-constructor-expr, object-field,
         object-type, readonly-type
 
 type ObjectType readonly & object {
     int[] val;
-    isolated function f1() returns int;
 };
 
-function init() {
-    ObjectType obj = object {
-        int[] val = [1, 2];
+ObjectType obj = object {
+    int[] val = [1, 2];
+};
 
-        isolated function f1() returns int {
-            return self.val[1];
-        }
-    };
-    io:println(obj.f1()); // @output 2
+isolated any[][] b = [[12], [obj.val]];
+
+function init() {
+    lock {
+        io:println(b[1][0]); // @output [1,2]
+    }
 }
+
+Test-Case: error
+Description: Test non-isolatedness of object field if it is not final, not have a type-descriptor that
+             is a subtype of readonly or isolated object {}, nor implicitly read-only.
+Labels: array-type, field-access-expr, int, list-constructor-expr, module-init-var-decl, object-constructor-expr,
+        object-field, var
+
+var obj = object {
+    int[] val = [23];
+};
+
+isolated int[][] b = [[12], obj.val]; // @error invalid initial value expression: expected an isolated expression
 
 Test-Case: output
 Description: Test whether an object-constructor-expr is implicitly isolated if it is implicitly readonly.

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -1,7 +1,7 @@
 Test-Case: output
 Description: Test defining a method of an object.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, module-type-defn,
+        object-constructor-expr, object-type
 
 type ObjectType object {
     int[] val;
@@ -26,8 +26,8 @@ function init() {
 
 Test-Case: error
 Description: Test defining mismatching method of an object at the object constructor.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, module-type-defn,
+        object-constructor-expr, object-type
 
 type ObjectType object {
     int[] val;
@@ -51,7 +51,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test defining methods of an object with meta data.
 Fail-Issue: ballerina-platform/ballerina-lang#34859
-Labels: annotation-decl, annotation, field-access-expr, method-defn, module-type-defn, object-constructor-expr,
+Labels: annotation-decl, annotation, field-access-expr, module-type-defn, object-constructor-expr,
         record-type, string, type-cast-expr, typeof-expr, var
 
 type Annot record {
@@ -77,8 +77,8 @@ function init() {
 
 Test-Case: output
 Description: Test defining methods of an object with visibility qualifiers.
-Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
-        module-type-defn, object-constructor-expr, object-field, object-type
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, module-type-defn,
+        object-constructor-expr, object-type
 
 function init() {
     var obj =  object {
@@ -100,8 +100,8 @@ function init() {
 Test-Case: error
 Description: Test accessing private method of an object.
 Fail-Issue: ballerina-platform/ballerina-lang#36417
-Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
-        module-type-defn, object-constructor-expr, object-field, object-type
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, module-type-defn,
+        object-constructor-expr, object-type
 
 function errorFunction() {
     var obj =  object {
@@ -118,7 +118,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test defining methods of an object with method qualifiers.
 Labels: array-type, field-access-expr, int, isolated-function, list-constructor-expr, member-access-expr,
-        method-call-expr, method-defn, object-constructor-expr, object-field, string, var
+        method-call-expr, object-constructor-expr, string, var
 
 function init() {
     var obj =  object {
@@ -141,7 +141,7 @@ function init() {
 
 Test-Case: output
 Description: Test invoking object method with transactional qualifier in a transactional context.
-Labels: commit-action, int, method-call-expr, method-defn, object-constructor-expr, transaction-stmt, var
+Labels: commit-action, int, method-call-expr, object-constructor-expr, transaction-stmt, var
 
 function init() returns error? {
     var obj = object {
@@ -157,7 +157,7 @@ function init() returns error? {
 
 Test-Case: error
 Description: Test invoking object method with transactional qualifier in a non-transactional context.
-Labels: int, method-call-expr, method-defn, object-constructor-expr, var
+Labels: int, method-call-expr, object-constructor-expr, var
 
 function errorFunction() {
     var _ =  object {
@@ -173,7 +173,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test accessing fields and methods of the object within the method-defn-body using self variable.
 Labels: additive-expr, array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr,
-        method-defn, object-constructor-expr, object-field, var
+        object-constructor-expr, var
 
 function init() {
     var obj =  object {
@@ -197,8 +197,8 @@ function init() {
 
 Test-Case: error
 Description: Test accessing fields and methods of the object within the method-defn-body without using self variable.
-Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
-        object-constructor-expr, object-field, var
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, 
+        object-constructor-expr, var
 
 function errorFunction() {
     var obj =  object {
@@ -223,8 +223,7 @@ Description: Test accessing the self variable only within the scope of a lock st
              self is part of a field-access-expr of the form self.f, where f is the name of an isolated field and the
              object-constructor-expr is explicitly isolated.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-object, list-constructor-expr,
-        lock-stmt, member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field,
-        readonly-type, var
+        lock-stmt, member-access-expr, method-call-expr, object-constructor-expr, readonly-type, var
 
 function init() {
     var obj = isolated object {
@@ -245,8 +244,8 @@ Test-Case: error
 Description: Test accessing the self variable without using a lock statement when the object-constructor-expr is
              explicitly isolated and self is part of a field-access-expr of the form self.f, where f is the name of a
              non-isolated field.
-Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, method-defn,
-        object-constructor-expr, object-field, var
+Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, 
+        object-constructor-expr, var
 
 function errorFunction() {
     var _ = isolated object {
@@ -261,7 +260,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test whether an isolated method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+        member-access-expr, method-call-expr, object-constructor-expr, readonly-type, var
 
 function init() {
     var obj = object {
@@ -281,7 +280,7 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+        member-access-expr, method-call-expr, object-constructor-expr, readonly-type, var
 
 function errorFunction() {
     var _ = object {
@@ -302,8 +301,7 @@ Description: Test whether an isolated method containing isolated-qual can only r
              if the variable is final or configurable and static type of the variable is a subtype of readonly or
              isolated object {}.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
-        readonly-type, var
+        member-access-expr, method-call-expr, module-init-var-decl, object-constructor-expr, readonly-type, var
 
 final int[] & readonly arr = [3, 4];
 
@@ -325,8 +323,7 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
-        readonly-type, var
+        member-access-expr, method-call-expr, module-init-var-decl, object-constructor-expr, readonly-type, var
 
 int[] & readonly arr = [3, 4];
 
@@ -340,7 +337,7 @@ function errorFunction() {
 
 Test-Case: error
 Description: Test whether an isolated method containing isolated-qual cannot mutate non-isolated module-level state.
-Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+Labels: int, isolated-function, module-init-var-decl, object-constructor-expr, var
 
 int intVal = 10;
 
@@ -357,8 +354,8 @@ function errorFunction() {
 Test-Case: output
 Description: Test whether an isolated method containing isolated-qual can only refer captured variables if they are
              final and have a static type that is a subtype of readonly|isolated object {}.
-Labels: explicit-anonymous-function-expr, int, isolated-function, method-call-expr, method-defn,
-        object-constructor-expr, object-field, var
+Labels: explicit-anonymous-function-expr, int, isolated-function, method-call-expr, 
+        object-constructor-expr, var
 
 function init() {
     final int val = 10;
@@ -371,8 +368,8 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated method containing isolated-qual can only refer captured variables if they are
              final and have a static type that is a subtype of readonly|isolated object {}.
-Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
-        object-constructor-expr, object-field, readonly-type, var
+Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, 
+        object-constructor-expr, readonly-type, var
 
 function errorFunction() {
     int & readonly val = 10;

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -25,6 +25,33 @@ function init() {
 }
 
 Test-Case: output
+Description: Test defining methods of an object with meta data.
+Fail-Issue: ballerina-platform/ballerina-lang#34859
+Labels: annotation-decl, annotation, field-access-expr, method-defn, module-type-defn, object-constructor-expr,
+        record-type, string, type-cast-expr, typeof-expr, var
+
+type Annot record {
+    string a;
+};
+
+annotation Annot v1 on object function;
+
+function init() {
+    var obj = object {
+        # This is a document.
+        # It is for an object function.
+        @v1 {
+            a: "v1"
+        }
+        function f1() {
+        }
+    };
+
+    Annot annot = <Annot>(typeof obj.f1).@v1;
+    io:println(annot.a); // @output v1
+}
+
+Test-Case: output
 Description: Test defining methods of an object with visibility qualifiers.
 Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
         object-constructor-expr, object-field, object-type

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -1,0 +1,305 @@
+Test-Case: output
+Description: Test defining a method of an object.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type
+
+type ObjectType object {
+    int[] val;
+    function func1() returns int;
+};
+
+function init() {
+    ObjectType obj = object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        function func1() returns int {
+            return 10;
+        }
+    };
+    io:println(obj.val); // @output [1,2]
+    io:println(obj.func1()); // @output 10
+}
+
+Test-Case: output
+Description: Test defining methods of an object with visibility qualifiers.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type
+
+type ObjectType object {
+    int[] val;
+    public function func2() returns string;
+};
+
+function init() {
+    ObjectType obj =  object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        private function func1() returns int {
+            return 10;
+        }
+
+        public function func2() returns string {
+            return "ABC";
+        }
+    };
+    io:println(obj.val); // @output [1,2]
+    io:println(obj.func2()); // @output ABC
+}
+
+Test-Case: output
+Description: Test defining methods of an object with method qualifiers.
+Labels: array-type, field-access-expr, int, isolated-function, list-constructor-expr, member-access-expr,
+        method-call-expr, method-defn, object-constructor-expr, object-field, string, var
+
+function init() {
+    var obj =  object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        transactional function func1() returns int {
+            return self.val[0];
+        }
+
+        public isolated function func2() returns string {
+            return "ABC";
+        }
+    };
+    io:println(obj.func2()); // @output ABC
+}
+
+Test-Case: output
+Description: Test accessing fields and methods of the object within the method-defn-body using self variable.
+Labels: additive-expr, array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr,
+        method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj =  object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        function func1() returns int {
+            return self.val[0];
+        }
+
+        function func2() returns int {
+            return self.val[1] + self.func1();
+        }
+    };
+    io:println(obj.func1()); // @output 1
+    io:println(obj.func2()); // @output 3
+}
+
+Test-Case: error
+Description: Test accessing fields and methods of the object within the method-defn-body without using self variable.
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
+        object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var obj =  object {
+        int[] val;
+
+        function init() {
+            val = [1, 2]; // @error undefined symbol
+        }
+
+        function func1() returns int {
+            return val[0]; // @error undefined symbol
+        }
+
+        function func2() returns int {
+            return func1(); // @error undefined function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test accessing the self variable only within the scope of a lock statement, except when
+             self is part of a field-access-expr of the form self.f, where f is the name of an isolated field, if
+             object-constructor-expr is explicitly isolated.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-object, list-constructor-expr,
+        lock-stmt, member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field,
+        readonly-type, var
+
+function init() {
+    var obj = isolated object {
+        private int[] val = [1, 2];
+        final readonly & int[] val2 = [3, 4];
+
+        function func1() returns int {
+            int sum = self.val2[1];
+            lock {
+                return sum + self.val[0];
+            }
+        }
+    };
+    io:println(obj.func1()); // @output 5
+}
+
+Test-Case: error
+Description: Test accessing the self variable without using a lock statement when the object-constructor-expr is
+             explicitly isolated and self is part of a field-access-expr of the form self.f, where f is the name of a
+             non-isolated field.
+Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, method-defn,
+        object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var _ = isolated object {
+        private int[] val = [1, 2];
+
+        function func1() returns int {
+            return self.val[0]; // @error invalid access of a mutable field of an isolated object outside a lock statement
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+
+function init() {
+    var obj = object {
+        final readonly & int[] val = [1, 2];
+
+        isolated function func1() returns int {
+            return self.val[0];
+        }
+
+        isolated function func2() returns int {
+            return self.val[1] + self.func1();
+        }
+    };
+    io:println(obj.func2()); // @output 3
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+
+function errorFunction() {
+    var _ = object {
+        final readonly & int[] val = [1, 2];
+
+        function func1() returns int {
+            return self.val[0];
+        }
+
+        isolated function func2() returns int {
+            return self.val[1] + self.func1(); // @error invalid invocation of a non-isolated function in an 'isolated' function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
+        readonly-type, var
+
+final int[] & readonly arr = [3, 4];
+
+function init() {
+    var obj = object {
+        final readonly & int[] val = [1, 2];
+
+        isolated function func1() returns int {
+            return self.val[0];
+        }
+
+        isolated function func2() returns int {
+            return self.val[1] + arr[1] + self.func1();
+        }
+    };
+    io:println(obj.func2()); // @output 7
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
+        readonly-type, var
+
+int[] & readonly arr = [3, 4];
+
+function errorFunction() {
+    var _ = object {
+        isolated function func1() returns int {
+            return arr[1]; // @error invalid access of mutable storage in an isolated function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, int, isolated-function, list-constructor-expr, lock-stmt, member-access-expr,
+        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+
+isolated int[] arr = [3, 4];
+
+function init() {
+    var obj = object {
+        isolated function func1() returns int {
+            lock {
+                arr[2] = 5;
+                return arr[0] + arr[2];
+            }
+        }
+    };
+    io:println(obj.func1()); // @output 8
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+
+int intVal = 10;
+
+function errorFunction() {
+    var _ = object {
+        isolated function func1() {
+            lock {
+                intVal = 5; // @error invalid access of mutable storage in an isolated function
+            }
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: explicit-anonymous-function-expr, int, isolated-function, method-call-expr, method-defn,
+        object-constructor-expr, object-field, var
+
+function init() {
+    final int val = 10;
+    var obj = object {
+        isolated function func1() returns int => val;
+    };
+    io:println(obj.func1()); // @output 10
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
+        object-constructor-expr, object-field, readonly-type, var
+
+function errorFunction() {
+    int & readonly val = 10;
+    var _ = object {
+        isolated function func1() returns int => val; // @error invalid access of mutable storage in an isolated function
+    };
+}

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -24,6 +24,30 @@ function init() {
     io:println(obj.func1()); // @output 10
 }
 
+Test-Case: error
+Description: Test defining mismatching method of an object at the object constructor.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type
+
+type ObjectType object {
+    int[] val;
+    function func1() returns int;
+};
+
+function errorFunction() {
+    ObjectType obj = object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        function func1() returns string {
+            return "A";
+        }
+    }; // @error incompatible types: expected 'ObjectType', found 'object { int[] val; function func1 () returns (string); }'
+}
+
 Test-Case: output
 Description: Test defining methods of an object with meta data.
 Fail-Issue: ballerina-platform/ballerina-lang#34859
@@ -56,29 +80,35 @@ Description: Test defining methods of an object with visibility qualifiers.
 Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
         object-constructor-expr, object-field, object-type
 
-type ObjectType object {
-    int[] val;
-    public function func2() returns string;
-};
-
-function init() {
-    ObjectType obj =  object {
-        int[] val;
-
-        function init() {
-            self.val = [1, 2];
-        }
+function errorFunction() {
+    var obj =  object {
+        private int[] val = [1, 2];
 
         private function func1() returns int {
-            return 10;
-        }
-
-        public function func2() returns string {
-            return "ABC";
+            return self.val[0];
         }
     };
-    io:println(obj.val); // @output [1,2]
-    io:println(obj.func2()); // @output ABC
+
+    int _ = obj.func1(); // @error attempt to refer to non-accessible symbol
+                         // @error undefined method 'func1' in object 'object { private int[] val; private function func1 () returns (int); }'
+}
+
+Test-Case: error
+Description: Test accessing private method of an object.
+Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
+        object-constructor-expr, object-field, object-type
+
+function errorFunction() {
+    var obj =  object {
+        private int[] val = [1, 2];
+
+        private function func1() returns int {
+            return self.val[0];
+        }
+    };
+
+    int _ = obj.func1(); // @error attempt to refer to non-accessible symbol
+                         // @error undefined method 'func1' in object 'object { private int[] val; private function func1 () returns (int); }'
 }
 
 Test-Case: output
@@ -103,6 +133,37 @@ function init() {
         }
     };
     io:println(obj.func2()); // @output ABC
+}
+
+Test-Case: output
+Description: Test invoking object method with transactional qualifier in a transactional context.
+Labels: commit-action, int, method-call-expr, method-defn, object-constructor-expr, transaction-stmt, var
+
+function init() returns error? {
+    var obj = object {
+        transactional function func1() returns int {
+            return 1;
+        }
+    };
+    transaction {
+        io:println(obj.func1()); // @output 1
+        check commit;
+    }
+}
+
+Test-Case: error
+Description: Test invoking object method with transactional qualifier in a non-transactional context.
+Labels: int, method-call-expr, method-defn, object-constructor-expr, var
+
+function errorFunction() {
+    var _ =  object {
+        transactional function func1() returns int {
+            return 1;
+        }
+        function func2() {
+            _ = self.func1(); // @error invoking transactional function outside transactional scope is prohibited
+        }
+    };
 }
 
 Test-Case: output
@@ -155,7 +216,7 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test accessing the self variable only within the scope of a lock statement, except when
-             self is part of a field-access-expr of the form self.f, where f is the name of an isolated field, if
+             self is part of a field-access-expr of the form self.f, where f is the name of an isolated field and the
              object-constructor-expr is explicitly isolated.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-object, list-constructor-expr,
         lock-stmt, member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field,
@@ -194,7 +255,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where it can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -214,7 +276,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where it can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -233,7 +296,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state can only be read if the variable is final and static type of the
+             variable is a subtype of readonly.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
         readonly-type, var
@@ -256,7 +321,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state cannot be mutated.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
         readonly-type, var
@@ -272,7 +338,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where isolated module-level state is read in lock statement.
 Labels: additive-expr, array-type, int, isolated-function, list-constructor-expr, lock-stmt, member-access-expr,
         method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
@@ -291,7 +358,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state cannot be mutated.
 Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
 int intVal = 10;
@@ -307,7 +375,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where captured variables must be both final and have a static type that is a subtype of
+             readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, isolated-function, method-call-expr, method-defn,
         object-constructor-expr, object-field, var
 
@@ -320,7 +390,9 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where captured variables must be both final and have a static type that is a subtype of
+             readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
         object-constructor-expr, object-field, readonly-type, var
 

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -255,8 +255,7 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where it can call only isolated functions.
+Description: Test whether an isolated method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -276,8 +275,7 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where it can call only isolated functions.
+Description: Test whether an isolated method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -296,9 +294,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state can only be read if the variable is final and static type of the
-             variable is a subtype of readonly.
+Description: Test whether an isolated method containing isolated-qual can only read an non-isolated module-level state
+             if the variable is final or configurable and static type of the variable is a subtype of readonly or
+             isolated object {}.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
         readonly-type, var
@@ -321,8 +319,7 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state cannot be mutated.
+Description: Test whether an isolated method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field,
         readonly-type, var
@@ -337,29 +334,8 @@ function errorFunction() {
     };
 }
 
-Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where isolated module-level state is read in lock statement.
-Labels: additive-expr, array-type, int, isolated-function, list-constructor-expr, lock-stmt, member-access-expr,
-        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
-
-isolated int[] arr = [3, 4];
-
-function init() {
-    var obj = object {
-        isolated function func1() returns int {
-            lock {
-                arr[2] = 5;
-                return arr[0] + arr[2];
-            }
-        }
-    };
-    io:println(obj.func1()); // @output 8
-}
-
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state cannot be mutated.
+Description: Test whether an isolated method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
 int intVal = 10;
@@ -375,9 +351,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where captured variables must be both final and have a static type that is a subtype of
-             readonly|isolated object {}.
+Description: Test whether an isolated method containing isolated-qual can only refer captured variables if they are
+             final and have a static type that is a subtype of readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, isolated-function, method-call-expr, method-defn,
         object-constructor-expr, object-field, var
 
@@ -390,9 +365,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where captured variables must be both final and have a static type that is a subtype of
-             readonly|isolated object {}.
+Description: Test whether an isolated method containing isolated-qual can only refer captured variables if they are
+             final and have a static type that is a subtype of readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
         object-constructor-expr, object-field, readonly-type, var
 

--- a/conformance/lang/expressions/object-constructor-expr/object_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_methods.balt
@@ -35,7 +35,7 @@ type ObjectType object {
 };
 
 function errorFunction() {
-    ObjectType obj = object {
+    ObjectType obj = object { // @error incompatible types: expected 'ObjectType', found 'object { int[] val; function func1 () returns (string); }'
         int[] val;
 
         function init() {
@@ -45,7 +45,7 @@ function errorFunction() {
         function func1() returns string {
             return "A";
         }
-    }; // @error incompatible types: expected 'ObjectType', found 'object { int[] val; function func1 () returns (string); }'
+    };
 }
 
 Test-Case: output
@@ -77,26 +77,31 @@ function init() {
 
 Test-Case: output
 Description: Test defining methods of an object with visibility qualifiers.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
+        module-type-defn, object-constructor-expr, object-field, object-type
 
-function errorFunction() {
+function init() {
     var obj =  object {
         private int[] val = [1, 2];
 
         private function func1() returns int {
             return self.val[0];
         }
+
+        public function func2() returns int {
+            return self.val[0];
+        }
     };
 
-    int _ = obj.func1(); // @error attempt to refer to non-accessible symbol
-                         // @error undefined method 'func1' in object 'object { private int[] val; private function func1 () returns (int); }'
+    int a = obj.func2();
+    io:println(a); // @output 1
 }
 
 Test-Case: error
 Description: Test accessing private method of an object.
-Labels: array-type, field-access-expr, int, list-constructor-expr, method-call-expr, method-defn, module-type-defn,
-        object-constructor-expr, object-field, object-type
+Fail-Issue: ballerina-platform/ballerina-lang#36417
+Labels: array-type, field-access-expr, int, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
+        module-type-defn, object-constructor-expr, object-field, object-type
 
 function errorFunction() {
     var obj =  object {
@@ -107,8 +112,7 @@ function errorFunction() {
         }
     };
 
-    int _ = obj.func1(); // @error attempt to refer to non-accessible symbol
-                         // @error undefined method 'func1' in object 'object { private int[] val; private function func1 () returns (int); }'
+    int _ = obj.func1(); // @error attempt to refer to non-accessible symbol and undefined method 'func1' in object 'object { private int[] val; private function func1 () returns (int); }'
 }
 
 Test-Case: output

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -40,11 +40,11 @@ type ObjectType client object {
 };
 
 function errorFunction() {
-    ObjectType obj = client object {
+    ObjectType obj = client object { // @error expected 'ObjectType', found 'isolated object { public function func1 () returns (string); }'
         remote function func1() returns string {
             return "A";
         }
-    }; // @error expected 'ObjectType', found 'isolated object { public function func1 () returns (string); }'
+    };
 }
 
 Test-Case: output
@@ -142,8 +142,7 @@ function init() returns error? {
 
 Test-Case: error
 Description: Test invoking object remote method with transactional qualifier in a non-transactional context.
-Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr,
-        transaction-stmt, var
+Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr, var
 
 function errorFunction() {
     var obj =  client object {

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -249,8 +249,7 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where it can call only isolated functions.
+Description: Test whether an isolated remote method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
         isolated-function, list-constructor-expr, member-access-expr, remote-method-defn, object-constructor-expr,
         object-field, readonly-type, var
@@ -273,8 +272,7 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where it can call only isolated functions.
+Description: Test whether an isolated remote method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, remote-method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -293,9 +291,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state can only be read if the variable is final and static type of the
-             variable is a subtype of readonly.
+Description: Test whether an isolated remote method containing isolated-qual can only read an non-isolated module-level
+             state if the variable is final or configurable and static type of the variable is a subtype of readonly or
+             isolated object {}.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
         isolated-function, list-constructor-expr, member-access-expr, method-call-expr, remote-method-defn,
         module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
@@ -320,8 +318,7 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state cannot be mutated.
+Description: Test whether an isolated remote method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, list-constructor-expr, member-access-expr,
         method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
 
@@ -335,32 +332,8 @@ function errorFunction() {
     };
 }
 
-Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where isolated module-level state is read in lock statement.
-Labels: additive-expr, array-type, client-remote-method-call-action, int, isolated-function, list-constructor-expr,
-        lock-stmt, member-access-expr, method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr,
-        object-field, var
-
-isolated int[] arr = [3, 4];
-
-function init() {
-    var obj = client object {
-        remote isolated function func1() returns int {
-            lock {
-                arr[2] = 5;
-                return arr[0] + arr[2];
-            }
-        }
-    };
-
-    int res = obj->func1();
-    io:println(res); // @output 8
-}
-
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where non-isolated module-level state cannot be mutated.
+Description: Test whether an isolated remote method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: int, isolated-function, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
 int intVal = 10;
@@ -376,9 +349,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where captured variables must be both final and have a static type that is a subtype of
-             readonly|isolated object {}.
+Description: Test whether an isolated remote method containing isolated-qual can only refer captured variables if they are
+             final and have a static type that is a subtype of readonly|isolated object {}.
 Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, var
 
@@ -393,9 +365,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
-             where captured variables must be both final and have a static type that is a subtype of
-             readonly|isolated object {}.
+Description: Test whether an isolated remote method containing isolated-qual can only refer captured variables if they are
+             final and have a static type that is a subtype of readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, readonly-type, var
 

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -31,6 +31,22 @@ function init() {
     io:println(res); // @output 10
 }
 
+Test-Case: error
+Description: Test defining mismatching remote method of an object at the object constructor.
+Labels: int, method-call-expr, remote-method-defn, module-type-defn, object-constructor-expr, object-field, object-type, string
+
+type ObjectType client object {
+    remote function func1() returns int;
+};
+
+function errorFunction() {
+    ObjectType obj = client object {
+        remote function func1() returns string {
+            return "A";
+        }
+    }; // @error expected 'ObjectType', found 'isolated object { public function func1 () returns (string); }'
+}
+
 Test-Case: output
 Description: Test defining methods of an object with meta data.
 Fail-Issue: ballerina-platform/ballerina-lang#36034
@@ -104,6 +120,38 @@ function init() {
 
     string res = obj->func2();
     io:println(res); // @output ABC
+}
+
+Test-Case: output
+Description: Test invoking object remote method with transactional qualifier in a transactional context.
+Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr,
+        transaction-stmt, var
+
+function init() returns error? {
+    var obj = client object {
+        transactional remote function func1() returns int {
+            return 1;
+        }
+    };
+    transaction {
+        int a = obj->func1();
+        io:println(a); // @output 1
+        check commit;
+    }
+}
+
+Test-Case: error
+Description: Test invoking object remote method with transactional qualifier in a non-transactional context.
+Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr,
+        transaction-stmt, var
+
+function errorFunction() {
+    var obj =  client object {
+        transactional remote function func1() returns int {
+            return 1;
+        }
+    };
+    _ = obj->func1(); // @error invoking transactional function outside transactional scope is prohibited
 }
 
 Test-Case: output
@@ -201,7 +249,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where it can call only isolated functions.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
         isolated-function, list-constructor-expr, member-access-expr, remote-method-defn, object-constructor-expr,
         object-field, readonly-type, var
@@ -224,7 +273,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where it can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
         member-access-expr, method-call-expr, remote-method-defn, object-constructor-expr, object-field, readonly-type, var
 
@@ -243,7 +293,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state can only be read if the variable is final and static type of the
+             variable is a subtype of readonly.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
         isolated-function, list-constructor-expr, member-access-expr, method-call-expr, remote-method-defn,
         module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
@@ -268,7 +320,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state cannot be mutated.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, list-constructor-expr, member-access-expr,
         method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
 
@@ -283,7 +336,8 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where isolated module-level state is read in lock statement.
 Labels: additive-expr, array-type, client-remote-method-call-action, int, isolated-function, list-constructor-expr,
         lock-stmt, member-access-expr, method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr,
         object-field, var
@@ -305,7 +359,8 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where non-isolated module-level state cannot be mutated.
 Labels: int, isolated-function, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
 int intVal = 10;
@@ -321,7 +376,9 @@ function errorFunction() {
 }
 
 Test-Case: output
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where captured variables must be both final and have a static type that is a subtype of
+             readonly|isolated object {}.
 Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, var
 
@@ -336,7 +393,9 @@ function init() {
 }
 
 Test-Case: error
-Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present,
+             where captured variables must be both final and have a static type that is a subtype of
+             readonly|isolated object {}.
 Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, readonly-type, var
 

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -1,7 +1,7 @@
 Test-Case: error
 Description: Test defining a remote method of an object when object-network-qual is not present in the
              object-constructor-expr.
-Labels: client-remote-method-call-action, field-access-expr, int, method-defn, object-constructor-expr, object-field
+Labels: client-remote-method-call-action, field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
 
 function errorFunction() {
     var _ = object {
@@ -12,7 +12,7 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test defining a remote method of a network interaction object.
-Labels: client-remote-method-call-action, field-access-expr, int, method-defn, object-constructor-expr, object-field
+Labels: client-remote-method-call-action, field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
 
 function init() {
     var obj = client object {
@@ -31,9 +31,36 @@ function init() {
     io:println(res); // @output 10
 }
 
+Test-Case: output
+Description: Test defining methods of an object with meta data.
+Fail-Issue: ballerina-platform/ballerina-lang#36034
+Labels: annotation-decl, annotation, field-access-expr, remote-method-defn, module-type-defn, object-constructor-expr,
+        record-type, string, type-cast-expr, typeof-expr, var
+
+type Annot record {
+    string a;
+};
+
+annotation Annot v1 on object function;
+
+function init() {
+    var obj = client object {
+        # This is a document.
+        # It is for an object function.
+        @v1 {
+            a: "v1"
+        }
+        remote function f1() {
+        }
+    };
+
+    Annot annot = <Annot>(typeof obj.f1).@v1;
+    io:println(annot.a); // @output v1
+}
+
 Test-Case: error
 Description: Test defining remote methods of a network interaction object with visibility qualifiers.
-Labels: field-access-expr, int, method-defn, object-constructor-expr, object-field
+Labels: field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
 
 function errorFunction() {
     var _ = client object {
@@ -55,7 +82,7 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test defining remote methods of a network interaction object with remote method qualifiers.
-Labels: client-remote-method-call-action, field-access-expr, int, member-access-expr, method-defn,
+Labels: client-remote-method-call-action, field-access-expr, int, member-access-expr, remote-method-defn,
         object-constructor-expr, object-field, string, var
 
 function init() {
@@ -83,7 +110,7 @@ Test-Case: output
 Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body using
              self variable.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, list-constructor-expr,
-        member-access-expr, method-defn, object-constructor-expr, object-field, var
+        member-access-expr, remote-method-defn, object-constructor-expr, object-field, var
 
 function init() {
     var obj = client object {
@@ -111,7 +138,7 @@ function init() {
 Test-Case: error
 Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body
              without using self variable.
-Labels: field-access-expr, function-call-expr, int, method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, function-call-expr, int, remote-method-defn, object-constructor-expr, object-field, var
 
 function errorFunction() {
     var obj = client object {
@@ -136,7 +163,7 @@ Description: Test accessing the self variable only within the scope of a lock st
              self is part of a field-access-expr of the form self.f, where f is the name of an isolated field, if
              object-constructor-expr is explicitly isolated.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-object, list-constructor-expr, lock-stmt, member-access-expr, method-defn, object-constructor-expr,
+        isolated-object, list-constructor-expr, lock-stmt, member-access-expr, remote-method-defn, object-constructor-expr,
         object-field, readonly-type, var
 
 function init() {
@@ -160,7 +187,7 @@ Test-Case: error
 Description: Test accessing the self variable without using a lock statement when a client object-constructor-expr is
              explicitly isolated and self is part of a field-access-expr of the form self.f, where f is the name of a
              non-isolated field.
-Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, method-defn,
+Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, remote-method-defn,
         object-constructor-expr, object-field, var
 
 function errorFunction() {
@@ -176,7 +203,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-function, list-constructor-expr, member-access-expr, method-defn, object-constructor-expr,
+        isolated-function, list-constructor-expr, member-access-expr, remote-method-defn, object-constructor-expr,
         object-field, readonly-type, var
 
 function init() {
@@ -199,7 +226,7 @@ function init() {
 Test-Case: error
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+        member-access-expr, method-call-expr, remote-method-defn, object-constructor-expr, object-field, readonly-type, var
 
 function errorFunction() {
     var _ = client object {
@@ -218,7 +245,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-function, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
+        isolated-function, list-constructor-expr, member-access-expr, method-call-expr, remote-method-defn,
         module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
 
 final int[] & readonly arr = [3, 4];
@@ -243,7 +270,7 @@ function init() {
 Test-Case: error
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, list-constructor-expr, member-access-expr,
-        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
+        method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
 
 int[] & readonly arr = [3, 4];
 
@@ -258,7 +285,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
 Labels: additive-expr, array-type, client-remote-method-call-action, int, isolated-function, list-constructor-expr,
-        lock-stmt, member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr,
+        lock-stmt, member-access-expr, method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr,
         object-field, var
 
 isolated int[] arr = [3, 4];
@@ -279,7 +306,7 @@ function init() {
 
 Test-Case: error
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
-Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+Labels: int, isolated-function, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, var
 
 int intVal = 10;
 
@@ -295,7 +322,7 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
-Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, method-defn,
+Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, var
 
 function init() {
@@ -310,7 +337,7 @@ function init() {
 
 Test-Case: error
 Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
-Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
+Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, remote-method-defn,
         object-constructor-expr, object-field, readonly-type, var
 
 function errorFunction() {

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -1,0 +1,321 @@
+Test-Case: error
+Description: Test defining a remote method of an object when object-network-qual is not present in the
+             object-constructor-expr.
+Labels: client-remote-method-call-action, field-access-expr, int, method-defn, object-constructor-expr, object-field
+
+function errorFunction() {
+    var _ = object {
+        remote function f1() { // @error remote qualifier only allowed in client and service objects
+        }
+    };
+}
+
+Test-Case: output
+Description: Test defining a remote method of a network interaction object.
+Labels: client-remote-method-call-action, field-access-expr, int, method-defn, object-constructor-expr, object-field
+
+function init() {
+    var obj = client object {
+        int val;
+
+        function init() {
+            self.val = 10;
+        }
+
+        remote function func1() returns int {
+            return self.val;
+        }
+    };
+
+    int res = obj->func1();
+    io:println(res); // @output 10
+}
+
+Test-Case: error
+Description: Test defining remote methods of a network interaction object with visibility qualifiers.
+Labels: field-access-expr, int, method-defn, object-constructor-expr, object-field
+
+function errorFunction() {
+    var _ = client object {
+        int val;
+
+        function init() {
+            self.val = 10;
+        }
+
+        private remote function func1() returns int { // @error remote remote method has a visibility qualifier
+            return self.val;
+        }
+
+        public remote function func2() returns string { // @error remote remote method has a visibility qualifier
+            return "ABC";
+        }
+    };
+}
+
+Test-Case: output
+Description: Test defining remote methods of a network interaction object with remote method qualifiers.
+Labels: client-remote-method-call-action, field-access-expr, int, member-access-expr, method-defn,
+        object-constructor-expr, object-field, string, var
+
+function init() {
+    var obj = client object {
+        int val;
+
+        function init() {
+            self.val = 1;
+        }
+
+        remote transactional function func1() returns int {
+            return self.val;
+        }
+
+        remote isolated function func2() returns string {
+            return "ABC";
+        }
+    };
+
+    string res = obj->func2();
+    io:println(res); // @output ABC
+}
+
+Test-Case: output
+Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body using
+             self variable.
+Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, list-constructor-expr,
+        member-access-expr, method-defn, object-constructor-expr, object-field, var
+
+function init() {
+    var obj = client object {
+        int[] val;
+
+        function init() {
+            self.val = [1, 2];
+        }
+
+        function func1() returns int {
+            return self.val[0];
+        }
+
+        remote function func2() returns int {
+            return self.val[1] + self.func1();
+        }
+    };
+
+    io:println(obj.func1()); // @output 1
+
+    int res = obj->func2();
+    io:println(res); // @output 3
+}
+
+Test-Case: error
+Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body
+             without using self variable.
+Labels: field-access-expr, function-call-expr, int, method-defn, object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var obj = client object {
+        int val = 10;
+
+        remote function func1() returns int {
+            return val; // @error undefined symbol
+        }
+
+        function func2() returns int {
+            return 10;
+        }
+
+        remote function func3() returns int {
+            return func2(); // @error undefined function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test accessing the self variable only within the scope of a lock statement, except when
+             self is part of a field-access-expr of the form self.f, where f is the name of an isolated field, if
+             object-constructor-expr is explicitly isolated.
+Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
+        isolated-object, list-constructor-expr, lock-stmt, member-access-expr, method-defn, object-constructor-expr,
+        object-field, readonly-type, var
+
+function init() {
+    var obj = isolated client object {
+        private int[] val = [1, 2];
+        final readonly & int[] val2 = [3, 4];
+
+        remote function func1() returns int {
+            int sum = self.val2[1];
+            lock {
+                return sum + self.val[0];
+            }
+        }
+    };
+
+    int res = obj->func1();
+    io:println(res); // @output 5
+}
+
+Test-Case: error
+Description: Test accessing the self variable without using a lock statement when a client object-constructor-expr is
+             explicitly isolated and self is part of a field-access-expr of the form self.f, where f is the name of a
+             non-isolated field.
+Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, method-defn,
+        object-constructor-expr, object-field, var
+
+function errorFunction() {
+    var _ = isolated client object {
+        private int[] val = [1, 2];
+
+        remote function func1() returns int {
+            return self.val[0]; // @error invalid access of a mutable field of an isolated object outside a lock statement
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
+        isolated-function, list-constructor-expr, member-access-expr, method-defn, object-constructor-expr,
+        object-field, readonly-type, var
+
+function init() {
+    var obj = client object {
+        final readonly & int[] val = [1, 2];
+
+        isolated function func1() returns int {
+            return self.val[0];
+        }
+
+        remote isolated function func2() returns int {
+            return self.val[1] + self.func1();
+        }
+    };
+
+    int res = obj->func2();
+    io:println(res); // @output 3
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
+        member-access-expr, method-call-expr, method-defn, object-constructor-expr, object-field, readonly-type, var
+
+function errorFunction() {
+    var _ = client object {
+        final readonly & int[] val = [1, 2];
+
+        function func1() returns int {
+            return self.val[0];
+        }
+
+        remote isolated function func2() returns int {
+            return self.val[1] + self.func1(); // @error invalid invocation of a non-isolated function in an 'isolated' function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
+        isolated-function, list-constructor-expr, member-access-expr, method-call-expr, method-defn,
+        module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
+
+final int[] & readonly arr = [3, 4];
+
+function init() {
+    var obj = client object {
+        final readonly & int[] val = [1, 2];
+
+        isolated function func1() returns int {
+            return self.val[0];
+        }
+
+        remote isolated function func2() returns int {
+            return self.val[1] + arr[1] + self.func1();
+        }
+    };
+
+    int res = obj->func2();
+    io:println(res); // @output 7
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, field-access-expr, int, intersection-type, list-constructor-expr, member-access-expr,
+        method-call-expr, method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
+
+int[] & readonly arr = [3, 4];
+
+function errorFunction() {
+    var _ = client object {
+        remote isolated function func1() returns int {
+            return arr[1]; // @error invalid access of mutable storage in an isolated function
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: additive-expr, array-type, client-remote-method-call-action, int, isolated-function, list-constructor-expr,
+        lock-stmt, member-access-expr, method-call-expr, method-defn, module-init-var-decl, object-constructor-expr,
+        object-field, var
+
+isolated int[] arr = [3, 4];
+
+function init() {
+    var obj = client object {
+        remote isolated function func1() returns int {
+            lock {
+                arr[2] = 5;
+                return arr[0] + arr[2];
+            }
+        }
+    };
+
+    int res = obj->func1();
+    io:println(res); // @output 8
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: int, isolated-function, method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+
+int intVal = 10;
+
+function errorFunction() {
+    var _ = client object {
+        remote isolated function func1() {
+            lock {
+                intVal = 5; // @error invalid access of mutable storage in an isolated function
+            }
+        }
+    };
+}
+
+Test-Case: output
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, method-defn,
+        object-constructor-expr, object-field, var
+
+function init() {
+    final int val = 10;
+    var obj = client object {
+        remote isolated function func1() returns int => val;
+    };
+
+    int res = obj->func1();
+    io:println(res); // @output 10
+}
+
+Test-Case: error
+Description: Test method-defn-body satisfying the requirements for an isolated function if isolated-qual is present.
+Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, method-defn,
+        object-constructor-expr, object-field, readonly-type, var
+
+function errorFunction() {
+    int & readonly val = 10;
+    var _ = client object {
+        remote isolated function func1() returns int => val; // @error invalid access of mutable storage in an isolated function
+    };
+}

--- a/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
+++ b/conformance/lang/expressions/object-constructor-expr/object_remote_methods.balt
@@ -1,7 +1,7 @@
 Test-Case: error
 Description: Test defining a remote method of an object when object-network-qual is not present in the
              object-constructor-expr.
-Labels: client-remote-method-call-action, field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
+Labels: client-remote-method-call-action, field-access-expr, int, remote-method, object-constructor-expr
 
 function errorFunction() {
     var _ = object {
@@ -12,7 +12,7 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test defining a remote method of a network interaction object.
-Labels: client-remote-method-call-action, field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
+Labels: client-remote-method-call-action, field-access-expr, int, remote-method, object-constructor-expr
 
 function init() {
     var obj = client object {
@@ -33,7 +33,7 @@ function init() {
 
 Test-Case: error
 Description: Test defining mismatching remote method of an object at the object constructor.
-Labels: int, method-call-expr, remote-method-defn, module-type-defn, object-constructor-expr, object-field, object-type, string
+Labels: int, method-call-expr, remote-method, module-type-defn, object-constructor-expr, object-type, string
 
 type ObjectType client object {
     remote function func1() returns int;
@@ -50,7 +50,7 @@ function errorFunction() {
 Test-Case: output
 Description: Test defining methods of an object with meta data.
 Fail-Issue: ballerina-platform/ballerina-lang#36034
-Labels: annotation-decl, annotation, field-access-expr, remote-method-defn, module-type-defn, object-constructor-expr,
+Labels: annotation-decl, annotation, field-access-expr, remote-method, module-type-defn, object-constructor-expr,
         record-type, string, type-cast-expr, typeof-expr, var
 
 type Annot record {
@@ -76,7 +76,7 @@ function init() {
 
 Test-Case: error
 Description: Test defining remote methods of a network interaction object with visibility qualifiers.
-Labels: field-access-expr, int, remote-method-defn, object-constructor-expr, object-field
+Labels: field-access-expr, int, remote-method, object-constructor-expr
 
 function errorFunction() {
     var _ = client object {
@@ -98,8 +98,8 @@ function errorFunction() {
 
 Test-Case: output
 Description: Test defining remote methods of a network interaction object with remote method qualifiers.
-Labels: client-remote-method-call-action, field-access-expr, int, member-access-expr, remote-method-defn,
-        object-constructor-expr, object-field, string, var
+Labels: client-remote-method-call-action, field-access-expr, int, member-access-expr, remote-method,
+        object-constructor-expr, string, var
 
 function init() {
     var obj = client object {
@@ -124,7 +124,7 @@ function init() {
 
 Test-Case: output
 Description: Test invoking object remote method with transactional qualifier in a transactional context.
-Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr,
+Labels: commit-action, client-remote-method-call-action, int, remote-method, object-constructor-expr,
         transaction-stmt, var
 
 function init() returns error? {
@@ -142,7 +142,7 @@ function init() returns error? {
 
 Test-Case: error
 Description: Test invoking object remote method with transactional qualifier in a non-transactional context.
-Labels: commit-action, client-remote-method-call-action, int, remote-method-defn, object-constructor-expr, var
+Labels: commit-action, client-remote-method-call-action, int, remote-method, object-constructor-expr, var
 
 function errorFunction() {
     var obj =  client object {
@@ -157,7 +157,7 @@ Test-Case: output
 Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body using
              self variable.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, list-constructor-expr,
-        member-access-expr, remote-method-defn, object-constructor-expr, object-field, var
+        member-access-expr, remote-method, object-constructor-expr, var
 
 function init() {
     var obj = client object {
@@ -185,7 +185,7 @@ function init() {
 Test-Case: error
 Description: Test accessing fields and remote methods of a network interaction object within the method-defn-body
              without using self variable.
-Labels: field-access-expr, function-call-expr, int, remote-method-defn, object-constructor-expr, object-field, var
+Labels: field-access-expr, function-call-expr, int, remote-method, object-constructor-expr, var
 
 function errorFunction() {
     var obj = client object {
@@ -210,8 +210,8 @@ Description: Test accessing the self variable only within the scope of a lock st
              self is part of a field-access-expr of the form self.f, where f is the name of an isolated field, if
              object-constructor-expr is explicitly isolated.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-object, list-constructor-expr, lock-stmt, member-access-expr, remote-method-defn, object-constructor-expr,
-        object-field, readonly-type, var
+        isolated-object, list-constructor-expr, lock-stmt, member-access-expr, remote-method, object-constructor-expr,
+        readonly-type, var
 
 function init() {
     var obj = isolated client object {
@@ -234,8 +234,8 @@ Test-Case: error
 Description: Test accessing the self variable without using a lock statement when a client object-constructor-expr is
              explicitly isolated and self is part of a field-access-expr of the form self.f, where f is the name of a
              non-isolated field.
-Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, remote-method-defn,
-        object-constructor-expr, object-field, var
+Labels: array-type, field-access-expr, int, isolated-object, list-constructor-expr, member-access-expr, remote-method,
+        object-constructor-expr, var
 
 function errorFunction() {
     var _ = isolated client object {
@@ -250,8 +250,8 @@ function errorFunction() {
 Test-Case: output
 Description: Test whether an isolated remote method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-function, list-constructor-expr, member-access-expr, remote-method-defn, object-constructor-expr,
-        object-field, readonly-type, var
+        isolated-function, list-constructor-expr, member-access-expr, remote-method, object-constructor-expr,
+        readonly-type, var
 
 function init() {
     var obj = client object {
@@ -273,7 +273,7 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated remote method containing isolated-qual can call only isolated functions.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, isolated-function, list-constructor-expr,
-        member-access-expr, method-call-expr, remote-method-defn, object-constructor-expr, object-field, readonly-type, var
+        member-access-expr, method-call-expr, remote-method, object-constructor-expr, readonly-type, var
 
 function errorFunction() {
     var _ = client object {
@@ -294,8 +294,8 @@ Description: Test whether an isolated remote method containing isolated-qual can
              state if the variable is final or configurable and static type of the variable is a subtype of readonly or
              isolated object {}.
 Labels: additive-expr, array-type, client-remote-method-call-action, field-access-expr, int, intersection-type,
-        isolated-function, list-constructor-expr, member-access-expr, method-call-expr, remote-method-defn,
-        module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
+        isolated-function, list-constructor-expr, member-access-expr, method-call-expr, remote-method,
+        module-init-var-decl, object-constructor-expr, readonly-type, var
 
 final int[] & readonly arr = [3, 4];
 
@@ -319,7 +319,7 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated remote method containing isolated-qual cannot mutate non-isolated module-level state.
 Labels: additive-expr, array-type, field-access-expr, int, intersection-type, list-constructor-expr, member-access-expr,
-        method-call-expr, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, readonly-type, var
+        method-call-expr, remote-method, module-init-var-decl, object-constructor-expr, readonly-type, var
 
 int[] & readonly arr = [3, 4];
 
@@ -333,7 +333,7 @@ function errorFunction() {
 
 Test-Case: error
 Description: Test whether an isolated remote method containing isolated-qual cannot mutate non-isolated module-level state.
-Labels: int, isolated-function, remote-method-defn, module-init-var-decl, object-constructor-expr, object-field, var
+Labels: int, isolated-function, remote-method, module-init-var-decl, object-constructor-expr, var
 
 int intVal = 10;
 
@@ -350,8 +350,8 @@ function errorFunction() {
 Test-Case: output
 Description: Test whether an isolated remote method containing isolated-qual can only refer captured variables if they are
              final and have a static type that is a subtype of readonly|isolated object {}.
-Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, remote-method-defn,
-        object-constructor-expr, object-field, var
+Labels: client-remote-method-call-action, explicit-anonymous-function-expr, int, method-call-expr, remote-method,
+        object-constructor-expr, var
 
 function init() {
     final int val = 10;
@@ -366,8 +366,8 @@ function init() {
 Test-Case: error
 Description: Test whether an isolated remote method containing isolated-qual can only refer captured variables if they are
              final and have a static type that is a subtype of readonly|isolated object {}.
-Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, remote-method-defn,
-        object-constructor-expr, object-field, readonly-type, var
+Labels: explicit-anonymous-function-expr, int, intersection-type, isolated-function, method-call-expr, remote-method,
+        object-constructor-expr, readonly-type, var
 
 function errorFunction() {
     int & readonly val = 10;


### PR DESCRIPTION
## Purpose
$title

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/35725