### PR TITLE
Change the committing branch to master

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone ballerina-dev-website
-        run: git clone https://ballerina-bot:$GITHUB_TOKEN@github.com/ballerina-platform/ballerina-dev-website.git
+        run: git clone -b master --single-branch https://ballerina-bot:$GITHUB_TOKEN@github.com/ballerina-platform/ballerina-dev-website.git
 
       - name: Clone ballerina-prod-website
         run: git clone https://ballerina-bot:$GITHUB_TOKEN@github.com/ballerina-platform/ballerina-platform.github.io.git
@@ -35,7 +35,7 @@ jobs:
       - name: Sync spec in master with ballerina-dev-website
         run: |
           cd ballerina-dev-website
-          git pull origin dev
+          git pull origin master
 
           git config --global user.email "ballerina-bot@ballerina.org"
           git config --global user.name "ballerina-bot"


### PR DESCRIPTION
## Purpose
Currently the spec changes are pushed into the `dev` branch of the ballerina-dev-website repo. We need to change this to `master` branch.

