### PR TITLE
Fix two typos

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -797,7 +797,7 @@ types found in some other structurally typed languages, such as Modula-3.
 The semantics of distinct types are based on type-ids. These are similar to the
 brands used by branded types. A distinct type is created by the use of the
 <code>distinct</code> keyword in either a <a
-href="#distinct-types">distinct-type-descriptor</a> or the
+href="#distinct_types">distinct-type-descriptor</a> or the
 <code>class-type-quals</code> of a <code>module-class-defn</code>. Each such
 occurrence of the <code>distinct</code> keyword has a distinct type-id, which
 uniquely identifies it within a Ballerina program. A type-id has three parts:

--- a/lang/spec.html
+++ b/lang/spec.html
@@ -6696,9 +6696,9 @@ checking-keyword := <code>check</code> | <code>checkpanic</code>
 Evaluates expression resulting in value v. If v has basic type error, then
 </p>
 <ul>
-<li>if the checking-keyword is <code>check</code>, then the check-expression
+<li>if the checking-keyword is <code>check</code>, then the checking-expr
 completes abruptly with a check-fail with associated value v;</li>
-<li>if the checking-keyword is <code>checkpanic</code>, then the check-expression
+<li>if the checking-keyword is <code>checkpanic</code>, then the checking-expr
 completes abruptly with a panic with associated value v.</li>
 </ul>
 <p>


### PR DESCRIPTION
## Purpose
Fix 
- `check-expression` -> `checking-expr`
- link to the distinct types section