### PR TITLE
Fix a typo

### DIFF
--- a/lang/spec.html
+++ b/lang/spec.html
@@ -2772,7 +2772,7 @@ class="grammar">singleton-type-descriptor := simple-const-expr
 </pre>
 <p>
 A singleton type is a type containing a single shape. A singleton type is
-described using an compile-time constant expression for a single value: the type
+described using a compile-time constant expression for a single value: the type
 contains the shape of that value. Note that it is possible for the
 variable-reference within the simple-const-expr to reference a structured value;
 in this case, the value will have its read-only bit set; a value without its


### PR DESCRIPTION
## Purpose

$title
`an compile-time constant expression...` should be `a compile-time constant expression...`
