### PR TITLE
Remove worker pool config from the listener

### DIFF
--- a/stdlib/proposals/task/task_listener.md
+++ b/stdlib/proposals/task/task_listener.md
@@ -6,6 +6,8 @@
   - TBD
 - Created date
   - 2025-01-30
+- Updated date
+  - 2025-05-07   
 - Issue
   - [1329](https://github.com/ballerina-platform/ballerina-spec/issues/1329)
 - State
@@ -85,10 +87,8 @@ The task listener requires a schedule configuration (one-time or recurring) and 
 # Listener configuration.
 #
 # + schedule - The schedule configuration for the listener
-# + workerPool - The worker pool configuration for the listener
 public type ListenerConfiguration record {|
     OneTimeConfiguration|RecurringConfiguration schedule;
-    WorkerPoolConfiguration? workerPool;
 |};
 
 # Recurring schedule configuration.
@@ -113,31 +113,7 @@ public type RecurringConfiguration record {|
 public type OneTimeConfiguration record {|
     time:Civil triggerTime;
 |};
-
-# Worker pool configuration.
-#
-# + workerCount - Specifies the number of workers that are available for the concurrent execution of jobs.
-#                 It should be a positive integer. The recommendation is to set a value less than 10. Default sets to 5.
-# + waitingTime - The number of seconds as a decimal the scheduler will tolerate a trigger to pass its next-fire-time
-#                 before being considered as `ignored the trigger`
-public type WorkerPoolConfiguration record {|
-    int workerCount = 5;
-    time:Seconds waitingTime = 5;
-|};
 ```
-
-If no worker pool is provided, the listener uses a global scheduler with the following configuration:
-
-```ballerina
-# Worker count for the global schedular
-public configurable int globalSchedularWorkerCount = 5;
-
-# Waiting time for the global schedular
-public configurable time:Seconds globalSchedularWaitingTime = 5;
-```
-
-> **Note:** If a worker pool is specified, the listener creates a new scheduler; otherwise, it uses
-> the global scheduler.
 
 #### Listener APIs
 


### PR DESCRIPTION
## Purpose
> This is to have a single global level scheduler for all the tasks to be scheduled