### PR TITLE
Add RSASSA-PSS (PS256) signature support BEP

### DIFF
--- a/beps/lib-crypto/8292_rsassa_pss_signature_support.md
+++ b/beps/lib-crypto/8292_rsassa_pss_signature_support.md
@@ -3,7 +3,7 @@
 - Authors
   - Randil Tharusha (@randilt)
 - Reviewed by
-  - @daneshk @ThisaruGuruge 
+  - @daneshk @ThisaruGuruge
 - Created date
   - 2025-10-03
 - Updated date
@@ -64,7 +64,7 @@ This proposal follows the existing architectural patterns of the Ballerina crypt
 
 Two new functions will be added to the `crypto` module following the exact naming pattern of existing RSA signature functions:
 
-````ballerina
+```ballerina
 # Returns the RSASSA-PSS with SHA-256 based signature value for the given data.
 # ```ballerina
 # string input = "Hello Ballerina";
@@ -81,9 +81,9 @@ Two new functions will be added to the `crypto` module following the exact namin
 # + privateKey - The private key used for signing
 # + return - The generated signature or else a `crypto:Error` if the private key is invalid
 public isolated function signRsaSsaPss256(byte[] input, PrivateKey privateKey) returns byte[]|Error;
-````
+```
 
-````ballerina
+```ballerina
 # Verifies the RSASSA-PSS with SHA-256 based signature.
 # ```ballerina
 # string input = "Hello Ballerina";
@@ -103,7 +103,7 @@ public isolated function signRsaSsaPss256(byte[] input, PrivateKey privateKey) r
 # + publicKey - The public key used for verification
 # + return - Validity of the signature or else a `crypto:Error` if the public key is invalid
 public isolated function verifyRsaSsaPss256Signature(byte[] data, byte[] signature, PublicKey publicKey) returns boolean|Error;
-````
+```
 
 ### Implementation Architecture
 


### PR DESCRIPTION
## Purpose

This PR adds a Ballerina Enhancement Proposal (BEP) for RSASSA-PSS (PS256) signature support in the Ballerina crypto module. The current crypto library only supports classic RSA signatures using PKCS#1 v1.5 padding, limiting developers who need modern cryptographic standards like JWT PS256, OAuth 2.0, and other security protocols that require or prefer RSASSA-PSS signatures.

Resolves [#8292](https://github.com/ballerina-platform/ballerina-library/issues/8292)

## Goals

- Document the technical specification for adding RSASSA-PSS signature generation and verification APIs to the Ballerina crypto module
- Provide comprehensive analysis of implementation approach, and design decisions
- Establish the roadmap for enabling PS256 support in higher-level modules like JWT
- Follow the standardized BEP process for platform-wide enhancements

## Related PRs
- [Add support for RSASSA-PSS (PS256) algorithm](https://github.com/ballerina-platform/module-ballerina-crypto/pull/612)