### PR TITLE
Add proposal for individual init parameters support in persist clients

### DIFF
--- a/beps/tool-persist/1406_support_for_individual_init_parameters_in_persist_client.md
+++ b/beps/tool-persist/1406_support_for_individual_init_parameters_in_persist_client.md
@@ -132,7 +132,7 @@ public function init(
 }
 ```
 
-> **Note:** For Non-SQL data stores, the init function will not change based on this option. It will remain as deafult where we use module level configurable variables.
+> **Note:** For non-SQL data stores, the init function will not change based on this option. It will remain as the default where we use module-level configurable variables.
 
 ### Build Integration
 


### PR DESCRIPTION
## Purpose

This proposal introduces support for individual initialization parameters in Ballerina persist clients, allowing for more flexible and programmatic database connection setups. It aims to improve client reusability and enhance the developer experience in low-code environments while maintaining backward compatibility.

Library issue: https://github.com/ballerina-platform/ballerina-library/issues/8505