### PR TITLE
Add native APIs to support dynamic log level change at runtime

### DIFF
--- a/beps/lib-log/1424_runtime_log_level_modification.md
+++ b/beps/lib-log/1424_runtime_log_level_modification.md
@@ -1,0 +1,261 @@
+# Runtime Log Level Modification Support for ballerina/log
+
+- Authors
+  - @daneshk
+- Reviewed by
+  - @TharmiganK
+- Created date
+  - 2026-02-03
+- Issue
+  - [1424](https://github.com/ballerina-platform/ballerina-spec/issues/1424)
+- State
+  - Submitted
+
+## Summary
+
+This proposal introduces Java APIs to modify log levels at runtime without application restart. The primary goal is to enable the WSO2 Integrator: ICP (Integration Control Plane) agent to dynamically adjust log levels for the root logger level, module-specific log levels, and custom loggers level created via the `fromConfig` API.
+
+## Goals
+
+- Provide Java APIs to retrieve the current log configuration at runtime.
+- Enable runtime modification of the global root log level.
+- Support adding, updating, and removing module-level log configurations at runtime.
+- Allow modification of log levels for custom loggers created via `fromConfig` API (when explicitly identified by the user).
+- Maintain backward compatibility with the existing `ballerina/log` API.
+- Ensure thread-safe operations for concurrent log level modifications.
+
+## Non-Goals
+
+- This proposal does not provide Ballerina-level public APIs for runtime log modification (APIs are Java-only for ICP agent use).
+- Log levels of custom loggers created without an explicit ID cannot be modified via ICP.
+- This proposal does not support modifying other logger configurations (format, destinations) at runtime.
+
+## Motivation
+
+In production environments, the ability to change log levels dynamically is crucial for debugging and monitoring without requiring application restarts. Currently, the only way to change log levels in Ballerina applications is through the `Config.toml` file, which requires an application restart to take effect.
+
+The WSO2 Integrator: ICP (Integration Control Plane) dashboard needs to provide operators with the ability to:
+1. View the current logging configuration of running applications.
+2. Increase log verbosity (e.g., switch to DEBUG) when investigating issues.
+3. Reduce log verbosity (e.g., switch to ERROR) to reduce noise and storage costs.
+4. Configure logging differently for specific modules without affecting others.
+
+This capability is essential for:
+- **Production debugging**: Temporarily enable DEBUG logging to diagnose issues without restarting the application.
+- **Performance optimization**: Reduce logging overhead by increasing log levels during high-load periods.
+- **Compliance**: Enable detailed audit logging on demand for compliance investigations.
+
+## Design
+
+### Backward Compatibility
+
+This proposal maintains full backward compatibility. All existing logging functionality continues to work unchanged:
+
+```ballerina
+// Existing usage - unchanged
+log:printInfo("Hello World!");
+
+// Existing custom logger - unchanged
+log:Logger myLogger = check log:fromConfig(level = log:DEBUG);
+myLogger.printInfo("Custom logger message");
+```
+
+### Custom Logger Identification
+
+To enable ICP to modify a custom logger's level, users must provide an explicit `id` when creating the logger. This proposal adds an optional `id` field to the `Config` record:
+
+```ballerina
+public type Config record {|
+    # Optional unique identifier for this logger. If provided, the logger will be visible
+    # in the ICP dashboard and its log level can be modified at runtime.
+    # If not provided, the logger's level cannot be changed via ICP.
+    string id?;
+    LogFormat format = format;
+    Level level = level;
+    readonly & OutputDestination[] destinations = destinations;
+    readonly & AnydataKeyValues keyValues = {...keyValues};
+    boolean enableSensitiveDataMasking = enableSensitiveDataMasking;
+|};
+```
+
+#### Usage Examples
+
+**Logger visible to ICP (can be configured at runtime):**
+```ballerina
+// Create a logger with an explicit ID - visible in ICP dashboard
+log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
+paymentLogger.printInfo("Processing payment");
+
+// ICP agent can later change this logger's level to DEBUG for debugging
+```
+
+**Logger not visible to ICP (internal use only):**
+```ballerina
+// Create a logger without ID - not visible in ICP dashboard
+log:Logger internalLogger = check log:fromConfig(level = log:DEBUG);
+internalLogger.printDebug("Internal debug message");
+
+// This logger's level cannot be changed via ICP
+```
+
+### Child Loggers
+
+Child loggers can be created from the root logger or from custom loggers (loggers created using `fromConfig` or loggers created by implementing the `Logger` interface) using the `withContext` method.
+
+Child loggers are not treated specially for runtime log level modification. They inherit their log level behavior from their parent logger:
+
+- When the parent logger's log level is changed at runtime, the child logger's effective log level changes as well.
+- Child loggers created from a custom logger with an `id` will automatically reflect any runtime log level changes made to that parent logger via ICP.
+
+```ballerina
+// Create a parent logger with an ID
+log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
+
+// Create child loggers with additional context
+log:Logger orderLogger = check paymentLogger.withContext(component = "order-handler");
+log:Logger refundLogger = check paymentLogger.withContext(component = "refund-handler");
+
+// All three loggers use INFO level initially
+paymentLogger.printInfo("Payment processed");
+orderLogger.printInfo("Order created");
+refundLogger.printInfo("Refund initiated");
+
+// When ICP changes "payment-service" to DEBUG level,
+// orderLogger and refundLogger will also log at DEBUG level
+```
+
+### Java APIs
+
+The following Java APIs are provided in `io.ballerina.stdlib.log.LogConfigManager` for ICP agent integration:
+
+#### Get Current Configuration
+
+```java
+/**
+ * Get the current log configuration.
+ *
+ * @return BMap containing:
+ *   - "rootLogger": map with "level" key containing the root log level
+ *   - "modules": map of module name -> map with "level" key
+ *   - "customLoggers": map of logger ID -> map with "level" key (only user-named loggers)
+ */
+public static BMap<BString, Object> getLogConfig();
+```
+
+#### Root Log Level Management
+
+```java
+/**
+ * Get the current global root log level.
+ *
+ * @return the root log level as BString
+ */
+public static BString getGlobalLogLevel();
+
+/**
+ * Set the global root log level.
+ *
+ * @param level the new log level (DEBUG, INFO, WARN, ERROR)
+ * @return null on success, BError on invalid level
+ */
+public static Object setGlobalLogLevel(BString level);
+```
+
+#### Module Log Level Management
+
+```java
+/**
+ * Set or update a module's log level.
+ *
+ * @param moduleName the fully qualified module name (e.g., "myorg/mymodule")
+ * @param level the new log level
+ * @return null on success, BError on invalid level
+ */
+public static Object setModuleLevel(BString moduleName, BString level);
+
+/**
+ * Remove a module's log level configuration.
+ * After removal, the module will use the root log level.
+ *
+ * @param moduleName the module name
+ * @return true if removed, false if not found
+ */
+public static boolean removeModuleLevel(BString moduleName);
+```
+
+#### Custom Logger Management
+
+```java
+/**
+ * Set a custom logger's log level.
+ * Only works for loggers created with an explicit ID.
+ *
+ * @param loggerId the logger ID provided during creation
+ * @param level the new log level
+ * @return null on success, BError if logger not found or invalid level
+ */
+public static Object setLoggerLevel(BString loggerId, BString level);
+```
+
+### Configuration Response Structure
+
+The `getLogConfig()` method returns a map with the following nested structure. This design allows for future extensibility to include additional configuration properties (like log context) without breaking the existing contract:
+
+```json
+{
+  "rootLogger": {
+    "level": "INFO"
+  },
+  "modules": {
+    "myorg/payment": {
+      "level": "DEBUG"
+    },
+    "myorg/notification": {
+      "level": "WARN"
+    }
+  },
+  "customLoggers": {
+    "payment-service": {
+      "level": "INFO"
+    },
+    "audit-logger": {
+      "level": "DEBUG"
+    }
+  }
+}
+```
+
+Note: Only custom loggers created with an explicit `id` appear in the `customLoggers` map.
+
+### Thread Safety
+
+All runtime configuration changes are thread-safe:
+- Root log level uses `AtomicReference<String>`
+- Module log levels use `ConcurrentHashMap<String, String>`
+- Custom logger levels use `ConcurrentHashMap<String, String>`
+
+### Log Level Validation
+
+All set operations validate the log level and return an error for invalid values:
+- Valid levels: `DEBUG`, `INFO`, `WARN`, `ERROR`
+- Level comparison is case-insensitive
+
+### Capabilities Summary
+
+**Can Do:**
+- Adjust the global root logger's log level
+- Add new module-level log configurations
+- Update existing module-level log configurations
+- Remove specific module-level log configurations
+- Modify log levels for custom loggers created with an explicit `id` via `fromConfig` API
+
+**Cannot Do:**
+- Modify log levels for custom loggers created without an `id`
+- Modify other logger configurations (format, destinations) at runtime
+- Access or modify loggers created directly using the `Logger` interface (not via `fromConfig`)
+
+## Future Considerations
+
+- Support for modifying log format at runtime
+- Support for adding/removing destinations at runtime
+- Ballerina-level public APIs for runtime log modification (if needed beyond ICP)

--- a/beps/lib-log/1424_runtime_log_level_modification.md
+++ b/beps/lib-log/1424_runtime_log_level_modification.md
@@ -26,7 +26,6 @@ This proposal introduces Ballerina-level public APIs to modify log levels at run
 - Child loggers (created via `withContext`) inherit their level from the parent and cannot have independent levels — `setLevel()` returns an unsupported operation error.
 - Child loggers are not registered in the registry.
 - Module-prefix user-provided logger IDs: `<org>/<module>:<user_id>`.
-- Treat each configured module as a separate logger in the unified logger registry, using the module name as the logger ID.
 - Auto-generate readable identifiers for loggers when no explicit ID is provided.
 - Ensure thread-safe operations for concurrent log level modifications.
 
@@ -201,7 +200,6 @@ The log module maintains an internal logger registry that tracks all registered 
 The registry tracks:
 
 - The root logger (registered with the well-known ID `"root"`)
-- Module loggers (each configured module is registered using the module name as its logger ID)
 - All loggers created via `fromConfig` (with module-prefixed or auto-generated IDs)
 
 Child loggers (created via `withContext`) are **not** registered in the registry. They always inherit their level from the parent logger and cannot have independent levels. The ID format is sufficient to differentiate logger types — no separate `LoggerKind` type is needed.
@@ -238,7 +236,7 @@ log:LoggerRegistry registry = log:getLoggerRegistry();
 
 // ICP retrieves all logger IDs
 string[] ids = registry.getIds();
-// Result: ["root", "myorg/payment", "myorg/payment:payment-service", "myorg/payment:init"]
+// Result: ["root", "myorg/payment:payment-service", "myorg/payment:init"]
 ```
 
 **Developer usage — get a logger instance and change its level:**
@@ -262,14 +260,7 @@ public function main() returns error? {
 
 ### Module Loggers
 
-Each module configured in `Config.toml` is automatically registered as a separate logger in the unified logger registry. The module name is used as the logger ID (e.g., `myorg/payment`). Module loggers participate in the same registry as `fromConfig` loggers.
-
-This unified approach means:
-
-- Module log levels can be modified at runtime using the same `setLevel()` / `getLevel()` APIs.
-- Module loggers appear in `registry.getIds()` alongside all other loggers, giving ICP a single, consistent view.
-- `registry.getById("myorg/payment")` returns the module's `Logger` instance for programmatic control.
-- There is no separate module-level configuration path — everything flows through the unified logger registry.
+Module log levels configured in `Config.toml` are applied at startup and filter log statements from each module statically. Module loggers are **not** registered in the logger registry.
 
 **Config.toml:**
 ```toml
@@ -285,24 +276,16 @@ name = "myorg/inventory"
 level = "WARN"
 ```
 
-**Runtime modification:**
+When the root logger receives a log statement from `myorg/payment`, it checks the configured module level (DEBUG) via a lock-free lookup and uses that instead of the root level (INFO). This filtering is purely static — module log levels cannot be changed at runtime via the registry.
+
+`getIds()` does not include module names:
 ```ballerina
-import ballerina/log;
-
 log:LoggerRegistry registry = log:getLoggerRegistry();
-
-// Module loggers are automatically registered — look them up by module name
-log:Logger? paymentLogger = registry.getById("myorg/payment");
-if paymentLogger is log:Logger {
-    check paymentLogger.setLevel(log:ERROR);  // Change at runtime
-}
-
-// getIds() lists all registered loggers
 string[] ids = registry.getIds();
-// ["root", "myorg/payment", "myorg/inventory", "myorg/payment:payment-service"]
+// ["root", "myorg/payment:payment-service"]  — module names are NOT listed
 ```
 
-**ID collision protection:** If a user calls `fromConfig(id = "myorg/payment")` using a name that matches a configured module, the existing duplicate-ID check returns an error, preventing collisions.
+To achieve runtime control over a module's log verbosity, create a dedicated logger via `fromConfig` within that module and control it through the registry.
 
 ### Child Loggers
 
@@ -369,7 +352,6 @@ All set operations validate the log level and return an error for invalid values
 - Retrieve and set log levels programmatically via `getLevel()` / `setLevel()` on root loggers, module loggers, and `fromConfig` loggers
 - Adjust the global root logger's log level
 - Discover all registered loggers via `LoggerRegistry` (`getIds()`, `getById()`)
-- Modify log levels for module loggers (configured in `Config.toml`) via ICP, using the module name as the logger ID
 - Modify log levels for all loggers created via `fromConfig` API (with module-prefixed or auto-generated IDs) via ICP
 - Child loggers automatically inherit level changes from their parent
 

--- a/beps/lib-log/1424_runtime_log_level_modification.md
+++ b/beps/lib-log/1424_runtime_log_level_modification.md
@@ -7,7 +7,7 @@
 - Created date
   - 2026-02-03
 - Last revised
-  - 2026-02-13
+  - 2026-02-17
 - Issue
   - [1424](https://github.com/ballerina-platform/ballerina-spec/issues/1424)
 - State
@@ -20,10 +20,12 @@ This proposal introduces Ballerina-level public APIs to modify log levels at run
 ## Goals
 
 - Provide Ballerina-level public APIs (`setLevel`, `getLevel`) on the `Logger` interface for runtime log level modification.
-- Provide a `LoggerRegistry` class with `getDetails()`, `getById()`, and `setLevel()` APIs for discovering and managing registered loggers.
-- Track logger kind (`root`, `module`, `custom`, `child`) in the registry for runtime differentiation of logger behaviour.
+- Provide a `LoggerRegistry` class with `getIds()` and `getById()` APIs for discovering registered loggers.
 - Enable runtime modification of the global root log level.
-- Allow modification of log levels for all loggers — root logger, module loggers, loggers created via `fromConfig`, and child loggers created via `withContext`.
+- Allow modification of log levels for root logger, module loggers, and loggers created via `fromConfig`.
+- Child loggers (created via `withContext`) inherit their level from the parent and cannot have independent levels — `setLevel()` returns an unsupported operation error.
+- Child loggers are not registered in the registry.
+- Module-prefix user-provided logger IDs: `<org>/<module>:<user_id>`.
 - Treat each configured module as a separate logger in the unified logger registry, using the module name as the logger ID.
 - Auto-generate readable identifiers for loggers when no explicit ID is provided.
 - Ensure thread-safe operations for concurrent log level modifications.
@@ -37,7 +39,7 @@ This proposal introduces Ballerina-level public APIs to modify log levels at run
 
 In production environments, the ability to change log levels dynamically is crucial for debugging and monitoring without requiring application restarts. Currently, the only way to change log levels in Ballerina applications is through the `Config.toml` file, which requires an application restart to take effect.
 
-The ICP (Integrated Control Panel) dashboard needs to provide operators with the ability to:
+The ICP (Integration Control Panel) dashboard needs to provide operators with the ability to:
 1. View the current logging configuration of running applications.
 2. Increase log verbosity (e.g., switch to DEBUG) when investigating issues.
 3. Reduce log verbosity (e.g., switch to ERROR) to reduce noise and storage costs.
@@ -81,13 +83,11 @@ Based on this analysis, the following features are included in this proposal:
 
 | Feature | Inspiration | Ballerina API |
 |---|---|---|
-| Enumerate all loggers | Java `getLoggerNames()`, Logback `getLoggerList()` | `LoggerRegistry.getDetails()` |
+| Enumerate all loggers | Java `getLoggerNames()`, Logback `getLoggerList()` | `LoggerRegistry.getIds()` |
 | Lookup by ID | Java/Logback `getLogger(name)`, Python `getLogger(name)` | `LoggerRegistry.getById(id)` |
-| Runtime level change | Java/Python `setLevel()` | `Logger.setLevel(level)` / `LoggerRegistry.setLevel(id, level)` |
+| Runtime level change | Java/Python `setLevel()` | `Logger.setLevel(level)` (returns `error?`) |
 | Get effective level | Java/Python `getEffectiveLevel()` | `Logger.getLevel()` (returns effective level) |
 | Reset to parent level | Java `setLevel(null)`, Python `setLevel(NOTSET)` | Deferred to future phase |
-| Independent child logger levels | Java/Python hierarchical model | `setLevel()` on child loggers |
-| Logger kind tracking | Java logger hierarchy types | `LoggerInfo.kind` (`root` / `module` / `custom` / `child`) |
 
 ## Design
 
@@ -108,9 +108,10 @@ public type Logger isolated object {
     public isolated function getLevel() returns Level;
 
     # Set the log level of this logger at runtime.
-    # This sets an explicit level override on this logger, independent of its parent.
+    # Returns an error if the operation is not supported (e.g., on child loggers).
     # + level - the new log level to set
-    public isolated function setLevel(Level level);
+    # + return - an error if the operation is not supported, nil on success
+    public isolated function setLevel(Level level) returns error?;
 
     # Existing methods (unchanged)
     public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
@@ -138,16 +139,16 @@ This breaking change is intentional and accepted by the design review. It is bet
 
 ### Logger Identification
 
-All loggers created via `fromConfig` are registered in the logger registry and are identifiable. An optional `id` field is added to the `Config` record. If the user provides an `id`, it is used as-is. If not provided, the log module auto-generates a readable identifier using the **module name + caller function name + counter** pattern.
+All loggers created via `fromConfig` are registered in the logger registry and are identifiable. An optional `id` field is added to the `Config` record. If the user provides an `id`, it is module-prefixed to produce a fully qualified ID of the form `<org>/<module>:<user_id>`. If no `id` is provided, the log module auto-generates a readable identifier using the **module name + caller function name** pattern (with a counter suffix only for subsequent loggers in the same function).
 
 #### Config Record
 
 ```ballerina
 public type Config record {|
-    # Optional unique identifier for this logger. If provided, this ID is used to identify
-    # the logger in the logger registry and ICP dashboard.
+    # Optional unique identifier for this logger. If provided, this ID is module-prefixed
+    # to produce a fully qualified ID: <org>/<module>:<user_id> (e.g., "myorg/payment:payment-service").
     # If not provided, a readable identifier is auto-generated using the pattern:
-    # <module>:<function>-<counter> (e.g., "myorg/payment:processOrder-1").
+    # <module>:<function> for the first logger, <module>:<function>-<counter> for subsequent ones.
     string id?;
     LogFormat format = format;
     Level level = level;
@@ -161,31 +162,32 @@ public type Config record {|
 
 When no `id` is provided, the log module generates a readable identifier by inspecting the caller's stack frame at logger creation time:
 
-- **Format**: `<module>:<functionName>-<counter>`
+- **Format**: `<module>:<functionName>` for the first logger in a function, `<module>:<functionName>-<counter>` for subsequent ones
 - **Examples**:
-  - `myorg/payment:processOrder-1`
-  - `myorg/payment:init-1`
-  - `myorg/payment:init-2` (second logger created in the same function)
+  - `myorg/payment:processOrder` (first logger in `processOrder`)
+  - `myorg/payment:processOrder-2` (second logger in `processOrder`)
+  - `myorg/payment:init` (first logger in `init`)
 
-The counter ensures uniqueness when multiple loggers are created in the same function. Stack frame inspection is performed only once at logger creation time, so there is no runtime performance impact on logging operations.
+The counter suffix is only added for the second and subsequent loggers in the same function, keeping IDs clean. Stack frame inspection is performed only once at logger creation time, so there is no runtime performance impact on logging operations.
 
 #### Usage Examples
 
 **Logger with explicit ID:**
 ```ballerina
-// Create a logger with an explicit ID - clearly identifiable in ICP dashboard
+// Create a logger with an explicit ID - module-prefixed in the registry
+// Registered as "myorg/payment:payment-service" (assuming called from myorg/payment module)
 log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
 paymentLogger.printInfo("Processing payment");
 
 // Programmatically change log level
-paymentLogger.setLevel(log:DEBUG);
+check paymentLogger.setLevel(log:DEBUG);
 
-// ICP agent can also change this logger's level using the ID "payment-service"
+// ICP agent can also change this logger's level using the full ID "myorg/payment:payment-service"
 ```
 
 **Logger with auto-generated ID:**
 ```ballerina
-// Create a logger without explicit ID - auto-generated ID (e.g., "myorg/payment:init-1")
+// Create a logger without explicit ID - auto-generated ID (e.g., "myorg/payment:init")
 log:Logger internalLogger = check log:fromConfig(level = log:DEBUG);
 internalLogger.printDebug("Internal debug message");
 
@@ -198,50 +200,26 @@ The log module maintains an internal logger registry that tracks all registered 
 
 The registry tracks:
 
+- The root logger (registered with the well-known ID `"root"`)
 - Module loggers (each configured module is registered using the module name as its logger ID)
-- All loggers created via `fromConfig` (with explicit or auto-generated IDs)
-- All child loggers created via `withContext`
+- All loggers created via `fromConfig` (with module-prefixed or auto-generated IDs)
 
-Each registry entry includes a `kind` field (`"root"`, `"module"`, `"custom"`, or `"child"`) that enables runtime differentiation of logger behaviour. This is important because:
-
-- **Root logger** (`kind: "root"`): The global root logger, registered with the well-known ID `"root"`. Changing its level affects all module-level `log:printInfo(...)` calls that don't have a module-specific level.
-- **Module loggers** (`kind: "module"`): Changing their level affects ALL `log:printInfo(...)` calls in that module.
-- **Custom loggers** (`kind: "custom"`): Created via `fromConfig()`. Changing their level only affects log statements made through that logger instance and its children.
-- **Child loggers** (`kind: "child"`): Inherit their parent's level by default; can be overridden independently via `setLevel()`.
+Child loggers (created via `withContext`) are **not** registered in the registry. They always inherit their level from the parent logger and cannot have independent levels. The ID format is sufficient to differentiate logger types — no separate `LoggerKind` type is needed.
 
 Note: Loggers implemented from scratch by implementing the `Logger` interface are referred to as **external loggers**. They are not tracked by the LoggerRegistry in the initial phase.
 
 ```ballerina
-# The kind of a registered logger, used for runtime differentiation of logger behaviour.
-public type LoggerKind "root"|"module"|"custom"|"child";
-
-# Represents information about a registered logger (JSON-serializable).
-public type LoggerInfo readonly & record {|
-    # The current log level
-    Level level;
-    # The kind of the logger
-    LoggerKind kind;
-|};
-
 # Provides access to the logger registry for discovering and managing registered loggers.
 public isolated class LoggerRegistry {
 
-    # Returns a JSON-friendly map of all registered loggers.
-    # The map key is the logger ID (user-provided or auto-generated),
-    # and the value contains the current log level and kind.
-    # + return - a map of logger ID to LoggerInfo
-    public isolated function getDetails() returns map<LoggerInfo>;
+    # Returns the IDs of all registered loggers.
+    # + return - an array of logger IDs
+    public isolated function getIds() returns string[];
 
     # Returns a specific logger instance by its ID.
     # + id - the logger identifier (user-provided or auto-generated)
     # + return - the Logger instance if found, or nil if no logger with the given ID exists
     public isolated function getById(string id) returns Logger?;
-
-    # Sets the log level for a registered logger by its ID.
-    # + id - the logger ID
-    # + level - the new log level
-    # + return - an error if the logger is not found
-    public isolated function setLevel(string id, Level level) returns error?;
 }
 
 # Returns the logger registry for discovering and managing registered loggers.
@@ -251,21 +229,16 @@ public isolated function getLoggerRegistry() returns LoggerRegistry;
 
 #### Usage Examples
 
-**ICP usage — list all loggers as JSON:**
+**ICP usage — list all loggers:**
 ```ballerina
 import ballerina/log;
 
 // Get the registry
 log:LoggerRegistry registry = log:getLoggerRegistry();
 
-// ICP retrieves the JSON-friendly map to render in the web editor
-map<log:LoggerInfo> loggers = registry.getDetails();
-// Result (JSON-serializable):
-// {
-//     "myorg/payment": { "level": "DEBUG", "kind": "module" },
-//     "payment-service": { "level": "INFO", "kind": "custom" },
-//     "myorg/myapp:main-1": { "level": "INFO", "kind": "child" }
-// }
+// ICP retrieves all logger IDs
+string[] ids = registry.getIds();
+// Result: ["root", "myorg/payment", "myorg/payment:payment-service", "myorg/payment:init"]
 ```
 
 **Developer usage — get a logger instance and change its level:**
@@ -274,39 +247,28 @@ import ballerina/log;
 
 public function main() returns error? {
     log:Logger logger1 = check log:fromConfig(id = "payment-service", level = log:INFO);
-    log:Logger logger2 = check log:fromConfig(level = log:DEBUG);
+    // Registered as "myorg/myapp:payment-service" (module-prefixed)
 
     log:LoggerRegistry registry = log:getLoggerRegistry();
 
     // Look up a logger by ID and change its level
-    log:Logger? logger = registry.getById("payment-service");
+    log:Logger? logger = registry.getById("myorg/myapp:payment-service");
     if logger is log:Logger {
-        logger.setLevel(log:DEBUG);
+        check logger.setLevel(log:DEBUG);
         log:Level level = logger.getLevel(); // DEBUG
     }
-
-    // Or change level directly via the registry using the logger ID
-    check registry.setLevel("payment-service", log:ERROR);
 }
-```
-
-**ICP usage — change a specific logger's level:**
-```ballerina
-// ICP changes a logger's level by ID through the registry
-log:LoggerRegistry registry = log:getLoggerRegistry();
-check registry.setLevel("payment-service", log:DEBUG);
 ```
 
 ### Module Loggers
 
-Each module configured in `Config.toml` is automatically registered as a separate logger in the unified logger registry. The module name is used as the logger ID (e.g., `myorg/payment`). Module loggers are children of the root logger and participate in the same registry as `fromConfig` and `withContext` loggers.
+Each module configured in `Config.toml` is automatically registered as a separate logger in the unified logger registry. The module name is used as the logger ID (e.g., `myorg/payment`). Module loggers participate in the same registry as `fromConfig` loggers.
 
 This unified approach means:
 
 - Module log levels can be modified at runtime using the same `setLevel()` / `getLevel()` APIs.
-- Module loggers appear in `registry.getDetails()` alongside all other loggers with `kind: "module"`, giving ICP a single, consistent view.
+- Module loggers appear in `registry.getIds()` alongside all other loggers, giving ICP a single, consistent view.
 - `registry.getById("myorg/payment")` returns the module's `Logger` instance for programmatic control.
-- `registry.setLevel("myorg/payment", log:ERROR)` changes the module's level by ID.
 - There is no separate module-level configuration path — everything flows through the unified logger registry.
 
 **Config.toml:**
@@ -332,19 +294,12 @@ log:LoggerRegistry registry = log:getLoggerRegistry();
 // Module loggers are automatically registered — look them up by module name
 log:Logger? paymentLogger = registry.getById("myorg/payment");
 if paymentLogger is log:Logger {
-    paymentLogger.setLevel(log:ERROR);  // Change at runtime
+    check paymentLogger.setLevel(log:ERROR);  // Change at runtime
 }
 
-// Or change level directly via registry
-check registry.setLevel("myorg/payment", log:DEBUG);
-
-// getDetails() shows module loggers with kind: "module"
-map<log:LoggerInfo> loggers = registry.getDetails();
-// {
-//     "myorg/payment": { "level": "DEBUG", "kind": "module" },
-//     "myorg/inventory": { "level": "WARN", "kind": "module" },
-//     "payment-service": { "level": "INFO", "kind": "custom" }
-// }
+// getIds() lists all registered loggers
+string[] ids = registry.getIds();
+// ["root", "myorg/payment", "myorg/inventory", "myorg/payment:payment-service"]
 ```
 
 **ID collision protection:** If a user calls `fromConfig(id = "myorg/payment")` using a name that matches a configured module, the existing duplicate-ID check returns an error, preventing collisions.
@@ -353,17 +308,15 @@ map<log:LoggerInfo> loggers = registry.getDetails();
 
 Child loggers can be created from the root logger or from loggers created using `fromConfig` using the `withContext` method.
 
-Child loggers inherit their log level from their parent logger by default, but support independent level overrides:
+Child loggers always inherit their log level from the parent logger:
 
-- By default, a child logger inherits its level from the parent. When the parent's level changes, the child's effective level changes too.
-- A child logger can have its own explicit level set via `setLevel()`, which overrides the inherited level.
-- Once a child has an explicit level, parent changes no longer affect it.
-- Child loggers are registered in the logger registry with auto-generated IDs and `kind: "child"`, so they are discoverable and modifiable via ICP.
+- A child logger's `getLevel()` always delegates to the parent's `getLevel()`. When the parent's level changes, the child's effective level changes too.
+- Calling `setLevel()` on a child logger returns an unsupported operation error. To change a child logger's effective level, change the parent's level instead.
+- Child loggers are **not** registered in the logger registry.
+- Child loggers can be chained (grandchild loggers) — each delegates `getLevel()` up the chain.
 
 ```ballerina
-// Root logger is initialized automatically from Config.toml (e.g., INFO)
-
-// Create a logger via fromConfig — this is a child of the root logger
+// Create a logger via fromConfig
 log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
 
 // Create child loggers with additional context
@@ -375,20 +328,14 @@ paymentLogger.printInfo("Payment processed");
 orderLogger.printInfo("Order created");
 refundLogger.printInfo("Refund initiated");
 
-// Change parent level — affects child loggers that haven't set their own level
-paymentLogger.setLevel(log:DEBUG);
+// Change parent level — all child loggers follow
+check paymentLogger.setLevel(log:DEBUG);
 orderLogger.getLevel();   // DEBUG (inherited from parent)
 refundLogger.getLevel();  // DEBUG (inherited from parent)
 
-// Set an independent level on a child logger
-orderLogger.setLevel(log:ERROR);
-orderLogger.getLevel();   // ERROR (explicit override)
-refundLogger.getLevel();  // DEBUG (still inherited from parent)
-
-// Parent changes no longer affect orderLogger (has explicit level)
-paymentLogger.setLevel(log:WARN);
-orderLogger.getLevel();   // ERROR (still explicit)
-refundLogger.getLevel();  // WARN (inherited from parent)
+// Attempting to set level on a child returns an error
+error? result = orderLogger.setLevel(log:ERROR);
+// result is error("Unsupported operation: cannot set log level on a child logger...")
 ```
 
 ### Backward Compatibility
@@ -404,7 +351,7 @@ log:Logger myLogger = check log:fromConfig(level = log:DEBUG);
 myLogger.printInfo("Custom logger message");
 ```
 
-The only breaking change is for developers who have implemented the `Logger` interface from scratch — they must add `getLevel` and `setLevel` method implementations.
+The only breaking change is for developers who have implemented the `Logger` interface from scratch — they must add `getLevel` and `setLevel` method implementations. Note that `setLevel` returns `error?` to allow child loggers to return an unsupported operation error.
 
 ### Thread Safety
 
@@ -419,17 +366,15 @@ All set operations validate the log level and return an error for invalid values
 ### Capabilities Summary
 
 **Can Do:**
-- Retrieve and set log levels programmatically via `getLevel()` / `setLevel()` on any logger instance
-- Set independent level overrides on child loggers
+- Retrieve and set log levels programmatically via `getLevel()` / `setLevel()` on root loggers, module loggers, and `fromConfig` loggers
 - Adjust the global root logger's log level
-- Discover and manage all registered loggers via `LoggerRegistry` (`getDetails()`, `getById()`, `setLevel()`)
-- Differentiate logger behaviour at runtime via `kind` (`root`, `module`, `custom`, `child`) in `LoggerInfo`
+- Discover all registered loggers via `LoggerRegistry` (`getIds()`, `getById()`)
 - Modify log levels for module loggers (configured in `Config.toml`) via ICP, using the module name as the logger ID
-- Modify log levels for all loggers created via `fromConfig` API (with explicit or auto-generated IDs) via ICP
-- Modify log levels for child loggers created via `withContext` via ICP
+- Modify log levels for all loggers created via `fromConfig` API (with module-prefixed or auto-generated IDs) via ICP
+- Child loggers automatically inherit level changes from their parent
 
 **Cannot Do (Initial Phase):**
-- Reset a child logger's level to inherit from its parent (`resetLevel`) — deferred to future phase along with parent-child tree tracking in the registry
+- Set independent log levels on child loggers — `setLevel()` returns an unsupported operation error
 - Modify log levels dynamically for custom loggers created by implementing the `Logger` interface from scratch (future enhancement)
 - Modify other logger configurations (format, destinations) at runtime
 

--- a/beps/lib-log/1424_runtime_log_level_modification.md
+++ b/beps/lib-log/1424_runtime_log_level_modification.md
@@ -3,9 +3,11 @@
 - Authors
   - @daneshk
 - Reviewed by
-  - @TharmiganK
+  - @sameerajayasoma, @shafreenAnfar, @manuranga, @anuruddhal, @TharmiganK
 - Created date
   - 2026-02-03
+- Last revised
+  - 2026-02-13
 - Issue
   - [1424](https://github.com/ballerina-platform/ballerina-spec/issues/1424)
 - State
@@ -13,62 +15,139 @@
 
 ## Summary
 
-This proposal introduces Java APIs to modify log levels at runtime without application restart. The primary goal is to enable the WSO2 Integrator: ICP (Integration Control Plane) agent to dynamically adjust log levels for the root logger level, module-specific log levels, and custom loggers level created via the `fromConfig` API.
+This proposal introduces Ballerina-level public APIs to modify log levels at runtime without application restart. The primary goal is to enable both developers (programmatic use) and the ICP (Integration Control Panel) agent to dynamically adjust log levels for the root logger, module-specific log levels, and loggers created via the `fromConfig` API. Additionally, a logger registry is introduced to provide visibility into all registered loggers and their current log levels.
 
 ## Goals
 
-- Provide Java APIs to retrieve the current log configuration at runtime.
+- Provide Ballerina-level public APIs (`setLevel`, `getLevel`) on the `Logger` interface for runtime log level modification.
+- Provide a `LoggerRegistry` class with `getDetails()`, `getById()`, and `setLevel()` APIs for discovering and managing registered loggers.
+- Track logger kind (`root`, `module`, `custom`, `child`) in the registry for runtime differentiation of logger behaviour.
 - Enable runtime modification of the global root log level.
-- Support adding, updating, and removing module-level log configurations at runtime.
-- Allow modification of log levels for custom loggers created via `fromConfig` API (when explicitly identified by the user).
-- Maintain backward compatibility with the existing `ballerina/log` API.
+- Allow modification of log levels for all loggers — root logger, module loggers, loggers created via `fromConfig`, and child loggers created via `withContext`.
+- Treat each configured module as a separate logger in the unified logger registry, using the module name as the logger ID.
+- Auto-generate readable identifiers for loggers when no explicit ID is provided.
 - Ensure thread-safe operations for concurrent log level modifications.
 
 ## Non-Goals
 
-- This proposal does not provide Ballerina-level public APIs for runtime log modification (APIs are Java-only for ICP agent use).
-- Log levels of custom loggers created without an explicit ID cannot be modified via ICP.
+- Dynamic log level changes for custom loggers (created by implementing the `Logger` interface from scratch) are not supported in the initial phase. A plan to support this will be designed in the future.
 - This proposal does not support modifying other logger configurations (format, destinations) at runtime.
 
 ## Motivation
 
 In production environments, the ability to change log levels dynamically is crucial for debugging and monitoring without requiring application restarts. Currently, the only way to change log levels in Ballerina applications is through the `Config.toml` file, which requires an application restart to take effect.
 
-The WSO2 Integrator: ICP (Integration Control Plane) dashboard needs to provide operators with the ability to:
+The ICP (Integrated Control Panel) dashboard needs to provide operators with the ability to:
 1. View the current logging configuration of running applications.
 2. Increase log verbosity (e.g., switch to DEBUG) when investigating issues.
 3. Reduce log verbosity (e.g., switch to ERROR) to reduce noise and storage costs.
 4. Configure logging differently for specific modules without affecting others.
+
+Beyond ICP, developers also need the ability to change log levels programmatically for use cases such as:
+- Adjusting log verbosity based on application state or external signals.
+- Building custom admin endpoints or control mechanisms.
 
 This capability is essential for:
 - **Production debugging**: Temporarily enable DEBUG logging to diagnose issues without restarting the application.
 - **Performance optimization**: Reduce logging overhead by increasing log levels during high-load periods.
 - **Compliance**: Enable detailed audit logging on demand for compliance investigations.
 
+## Logger Registry in Other Languages
+
+The following comparison of logger registry support across popular logging libraries informed the design decisions in this proposal.
+
+| Feature | Java (JUL / Logback) | Python (`logging`) | Go (`slog` / `zap`) | .NET (`Microsoft.Extensions.Logging`) | Rust (`log` / `tracing`) |
+|---|---|---|---|---|---|
+| **Auto-registration** | Yes | Yes | No registry | Yes (get-or-create) | N/A (single global) |
+| **Enumerate all loggers** | `getLoggerNames()` / `getLoggerList()` | `manager.loggerDict` | Not supported | Not exposed publicly | N/A |
+| **Lookup by name** | `getLogger(name)` / `exists(name)` | `getLogger(name)` | Not supported | `CreateLogger(name)` | N/A |
+| **Runtime level change** | `setLevel()` | `setLevel()` | `LevelVar.Set()` / `AtomicLevel.SetLevel()` | Config reload | `set_max_level()` (global only) |
+| **Hierarchical loggers** | Yes (dot-separated) | Yes (dot-separated) | No | Partial (filter rules) | No |
+| **Reset to parent level** | `setLevel(null)` | `setLevel(NOTSET)` | N/A | Remove filter rule + reload | N/A |
+| **Attach handlers at runtime** | `addHandler()` / `removeHandler()` | `addHandler()` / `removeHandler()` | No | `AddProvider()` (no remove) | No |
+| **Level change callbacks** | `LoggerContextListener` (Logback) | No | No | `IOptionsMonitor.OnChange()` | No |
+
+### Key Observations
+
+- **Java and Python have the richest registry models** — true named-logger registries with hierarchical inheritance, enumeration, lookup, and the ability to reset a logger to inherit from its parent via `setLevel(null)` / `setLevel(NOTSET)`.
+- **Go has no logger registry** — loggers are values passed around explicitly. Dynamic levels are handled via atomic variables (`LevelVar`, `AtomicLevel`). Zap's `AtomicLevel` also serves as an `http.Handler` for operational tooling.
+- **.NET is configuration-driven** — the logger cache is internal and not exposed. Level changes flow through the options/configuration system with file-watcher-based reload.
+- **Rust is intentionally minimal** — one global logger, one global level. The `tracing` crate adds composable layers with a `reload` module for swapping filters at runtime, but has no named-logger registry.
+- **Only Java and Python support "reset to parent level"** — this proposal defers `resetLevel()` to a future phase to avoid burdening custom logger implementors with parent-child semantics they may not have.
+
+### Features Adopted in This Proposal
+
+Based on this analysis, the following features are included in this proposal:
+
+| Feature | Inspiration | Ballerina API |
+|---|---|---|
+| Enumerate all loggers | Java `getLoggerNames()`, Logback `getLoggerList()` | `LoggerRegistry.getDetails()` |
+| Lookup by ID | Java/Logback `getLogger(name)`, Python `getLogger(name)` | `LoggerRegistry.getById(id)` |
+| Runtime level change | Java/Python `setLevel()` | `Logger.setLevel(level)` / `LoggerRegistry.setLevel(id, level)` |
+| Get effective level | Java/Python `getEffectiveLevel()` | `Logger.getLevel()` (returns effective level) |
+| Reset to parent level | Java `setLevel(null)`, Python `setLevel(NOTSET)` | Deferred to future phase |
+| Independent child logger levels | Java/Python hierarchical model | `setLevel()` on child loggers |
+| Logger kind tracking | Java logger hierarchy types | `LoggerInfo.kind` (`root` / `module` / `custom` / `child`) |
+
 ## Design
 
-### Backward Compatibility
+### Changes to the `Logger` Interface
 
-This proposal maintains full backward compatibility. All existing logging functionality continues to work unchanged:
+The `Logger` object type is extended with two new methods: `getLevel` and `setLevel`. This is a **breaking change** for developers who have implemented custom loggers from scratch by implementing the `Logger` interface. However, this does not affect the most common use cases — root loggers and child loggers — which will continue to work without any changes.
+
+Note: `resetLevel()` is intentionally **not** included on the `Logger` interface. Custom logger implementors may not have a parent-child concept, so `resetLevel()` would be confusing and have no meaningful implementation. The `resetLevel` capability is deferred to a future phase and will be added to the `LoggerRegistry` class, where it can operate on internally managed loggers that have parent-child relationships.
 
 ```ballerina
-// Existing usage - unchanged
-log:printInfo("Hello World!");
+# Logger object type defines an interface for logging messages
+public type Logger isolated object {
 
-// Existing custom logger - unchanged
-log:Logger myLogger = check log:fromConfig(level = log:DEBUG);
-myLogger.printInfo("Custom logger message");
+    # Get the effective log level of this logger.
+    # If this logger has an explicitly set level, returns that level.
+    # If not, returns the inherited level from the parent logger.
+    # + return - the effective log level
+    public isolated function getLevel() returns Level;
+
+    # Set the log level of this logger at runtime.
+    # This sets an explicit level override on this logger, independent of its parent.
+    # + level - the new log level to set
+    public isolated function setLevel(Level level);
+
+    # Existing methods (unchanged)
+    public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+
+    public isolated function printInfo(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+
+    public isolated function printWarn(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+
+    public isolated function printError(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+
+    public isolated function withContext(*KeyValues keyValues) returns Logger|error;
+};
 ```
 
-### Custom Logger Identification
+#### Breaking Change Impact
 
-To enable ICP to modify a custom logger's level, users must provide an explicit `id` when creating the logger. This proposal adds an optional `id` field to the `Config` record:
+| Logger Type | Impact |
+|---|---|
+| Root logger (`log:printInfo(...)`) | No change |
+| Child loggers (via `withContext`) | No change |
+| Loggers from `fromConfig` | No change (implementation updated internally) |
+| Custom loggers (implementing `Logger` interface from scratch) | **Breaking** — must add `getLevel` and `setLevel` implementations |
+
+This breaking change is intentional and accepted by the design review. It is better to introduce it now while the custom logger adoption is low.
+
+### Logger Identification
+
+All loggers created via `fromConfig` are registered in the logger registry and are identifiable. An optional `id` field is added to the `Config` record. If the user provides an `id`, it is used as-is. If not provided, the log module auto-generates a readable identifier using the **module name + caller function name + counter** pattern.
+
+#### Config Record
 
 ```ballerina
 public type Config record {|
-    # Optional unique identifier for this logger. If provided, the logger will be visible
-    # in the ICP dashboard and its log level can be modified at runtime.
-    # If not provided, the logger's level cannot be changed via ICP.
+    # Optional unique identifier for this logger. If provided, this ID is used to identify
+    # the logger in the logger registry and ICP dashboard.
+    # If not provided, a readable identifier is auto-generated using the pattern:
+    # <module>:<function>-<counter> (e.g., "myorg/payment:processOrder-1").
     string id?;
     LogFormat format = format;
     Level level = level;
@@ -78,37 +157,213 @@ public type Config record {|
 |};
 ```
 
+#### Auto-Generated Identifier
+
+When no `id` is provided, the log module generates a readable identifier by inspecting the caller's stack frame at logger creation time:
+
+- **Format**: `<module>:<functionName>-<counter>`
+- **Examples**:
+  - `myorg/payment:processOrder-1`
+  - `myorg/payment:init-1`
+  - `myorg/payment:init-2` (second logger created in the same function)
+
+The counter ensures uniqueness when multiple loggers are created in the same function. Stack frame inspection is performed only once at logger creation time, so there is no runtime performance impact on logging operations.
+
 #### Usage Examples
 
-**Logger visible to ICP (can be configured at runtime):**
+**Logger with explicit ID:**
 ```ballerina
-// Create a logger with an explicit ID - visible in ICP dashboard
+// Create a logger with an explicit ID - clearly identifiable in ICP dashboard
 log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
 paymentLogger.printInfo("Processing payment");
 
-// ICP agent can later change this logger's level to DEBUG for debugging
+// Programmatically change log level
+paymentLogger.setLevel(log:DEBUG);
+
+// ICP agent can also change this logger's level using the ID "payment-service"
 ```
 
-**Logger not visible to ICP (internal use only):**
+**Logger with auto-generated ID:**
 ```ballerina
-// Create a logger without ID - not visible in ICP dashboard
+// Create a logger without explicit ID - auto-generated ID (e.g., "myorg/payment:init-1")
 log:Logger internalLogger = check log:fromConfig(level = log:DEBUG);
 internalLogger.printDebug("Internal debug message");
 
-// This logger's level cannot be changed via ICP
+// This logger is still visible in ICP and its level can be changed via the auto-generated ID
 ```
+
+### Logger Registry
+
+The log module maintains an internal logger registry that tracks all registered loggers. Access to the registry is provided via the `LoggerRegistry` class, obtained by calling `getLoggerRegistry()`. The registry groups all discovery and management operations in one place, avoiding standalone function proliferation and making it easy to extend in the future.
+
+The registry tracks:
+
+- Module loggers (each configured module is registered using the module name as its logger ID)
+- All loggers created via `fromConfig` (with explicit or auto-generated IDs)
+- All child loggers created via `withContext`
+
+Each registry entry includes a `kind` field (`"root"`, `"module"`, `"custom"`, or `"child"`) that enables runtime differentiation of logger behaviour. This is important because:
+
+- **Root logger** (`kind: "root"`): The global root logger, registered with the well-known ID `"root"`. Changing its level affects all module-level `log:printInfo(...)` calls that don't have a module-specific level.
+- **Module loggers** (`kind: "module"`): Changing their level affects ALL `log:printInfo(...)` calls in that module.
+- **Custom loggers** (`kind: "custom"`): Created via `fromConfig()`. Changing their level only affects log statements made through that logger instance and its children.
+- **Child loggers** (`kind: "child"`): Inherit their parent's level by default; can be overridden independently via `setLevel()`.
+
+Note: Loggers implemented from scratch by implementing the `Logger` interface are referred to as **external loggers**. They are not tracked by the LoggerRegistry in the initial phase.
+
+```ballerina
+# The kind of a registered logger, used for runtime differentiation of logger behaviour.
+public type LoggerKind "root"|"module"|"custom"|"child";
+
+# Represents information about a registered logger (JSON-serializable).
+public type LoggerInfo readonly & record {|
+    # The current log level
+    Level level;
+    # The kind of the logger
+    LoggerKind kind;
+|};
+
+# Provides access to the logger registry for discovering and managing registered loggers.
+public isolated class LoggerRegistry {
+
+    # Returns a JSON-friendly map of all registered loggers.
+    # The map key is the logger ID (user-provided or auto-generated),
+    # and the value contains the current log level and kind.
+    # + return - a map of logger ID to LoggerInfo
+    public isolated function getDetails() returns map<LoggerInfo>;
+
+    # Returns a specific logger instance by its ID.
+    # + id - the logger identifier (user-provided or auto-generated)
+    # + return - the Logger instance if found, or nil if no logger with the given ID exists
+    public isolated function getById(string id) returns Logger?;
+
+    # Sets the log level for a registered logger by its ID.
+    # + id - the logger ID
+    # + level - the new log level
+    # + return - an error if the logger is not found
+    public isolated function setLevel(string id, Level level) returns error?;
+}
+
+# Returns the logger registry for discovering and managing registered loggers.
+# + return - the LoggerRegistry instance
+public isolated function getLoggerRegistry() returns LoggerRegistry;
+```
+
+#### Usage Examples
+
+**ICP usage — list all loggers as JSON:**
+```ballerina
+import ballerina/log;
+
+// Get the registry
+log:LoggerRegistry registry = log:getLoggerRegistry();
+
+// ICP retrieves the JSON-friendly map to render in the web editor
+map<log:LoggerInfo> loggers = registry.getDetails();
+// Result (JSON-serializable):
+// {
+//     "myorg/payment": { "level": "DEBUG", "kind": "module" },
+//     "payment-service": { "level": "INFO", "kind": "custom" },
+//     "myorg/myapp:main-1": { "level": "INFO", "kind": "child" }
+// }
+```
+
+**Developer usage — get a logger instance and change its level:**
+```ballerina
+import ballerina/log;
+
+public function main() returns error? {
+    log:Logger logger1 = check log:fromConfig(id = "payment-service", level = log:INFO);
+    log:Logger logger2 = check log:fromConfig(level = log:DEBUG);
+
+    log:LoggerRegistry registry = log:getLoggerRegistry();
+
+    // Look up a logger by ID and change its level
+    log:Logger? logger = registry.getById("payment-service");
+    if logger is log:Logger {
+        logger.setLevel(log:DEBUG);
+        log:Level level = logger.getLevel(); // DEBUG
+    }
+
+    // Or change level directly via the registry using the logger ID
+    check registry.setLevel("payment-service", log:ERROR);
+}
+```
+
+**ICP usage — change a specific logger's level:**
+```ballerina
+// ICP changes a logger's level by ID through the registry
+log:LoggerRegistry registry = log:getLoggerRegistry();
+check registry.setLevel("payment-service", log:DEBUG);
+```
+
+### Module Loggers
+
+Each module configured in `Config.toml` is automatically registered as a separate logger in the unified logger registry. The module name is used as the logger ID (e.g., `myorg/payment`). Module loggers are children of the root logger and participate in the same registry as `fromConfig` and `withContext` loggers.
+
+This unified approach means:
+
+- Module log levels can be modified at runtime using the same `setLevel()` / `getLevel()` APIs.
+- Module loggers appear in `registry.getDetails()` alongside all other loggers with `kind: "module"`, giving ICP a single, consistent view.
+- `registry.getById("myorg/payment")` returns the module's `Logger` instance for programmatic control.
+- `registry.setLevel("myorg/payment", log:ERROR)` changes the module's level by ID.
+- There is no separate module-level configuration path — everything flows through the unified logger registry.
+
+**Config.toml:**
+```toml
+[ballerina.log]
+level = "INFO"
+
+[[ballerina.log.modules]]
+name = "myorg/payment"
+level = "DEBUG"
+
+[[ballerina.log.modules]]
+name = "myorg/inventory"
+level = "WARN"
+```
+
+**Runtime modification:**
+```ballerina
+import ballerina/log;
+
+log:LoggerRegistry registry = log:getLoggerRegistry();
+
+// Module loggers are automatically registered — look them up by module name
+log:Logger? paymentLogger = registry.getById("myorg/payment");
+if paymentLogger is log:Logger {
+    paymentLogger.setLevel(log:ERROR);  // Change at runtime
+}
+
+// Or change level directly via registry
+check registry.setLevel("myorg/payment", log:DEBUG);
+
+// getDetails() shows module loggers with kind: "module"
+map<log:LoggerInfo> loggers = registry.getDetails();
+// {
+//     "myorg/payment": { "level": "DEBUG", "kind": "module" },
+//     "myorg/inventory": { "level": "WARN", "kind": "module" },
+//     "payment-service": { "level": "INFO", "kind": "custom" }
+// }
+```
+
+**ID collision protection:** If a user calls `fromConfig(id = "myorg/payment")` using a name that matches a configured module, the existing duplicate-ID check returns an error, preventing collisions.
 
 ### Child Loggers
 
-Child loggers can be created from the root logger or from custom loggers (loggers created using `fromConfig` or loggers created by implementing the `Logger` interface) using the `withContext` method.
+Child loggers can be created from the root logger or from loggers created using `fromConfig` using the `withContext` method.
 
-Child loggers are not treated specially for runtime log level modification. They inherit their log level behavior from their parent logger:
+Child loggers inherit their log level from their parent logger by default, but support independent level overrides:
 
-- When the parent logger's log level is changed at runtime, the child logger's effective log level changes as well.
-- Child loggers created from a custom logger with an `id` will automatically reflect any runtime log level changes made to that parent logger via ICP.
+- By default, a child logger inherits its level from the parent. When the parent's level changes, the child's effective level changes too.
+- A child logger can have its own explicit level set via `setLevel()`, which overrides the inherited level.
+- Once a child has an explicit level, parent changes no longer affect it.
+- Child loggers are registered in the logger registry with auto-generated IDs and `kind: "child"`, so they are discoverable and modifiable via ICP.
 
 ```ballerina
-// Create a parent logger with an ID
+// Root logger is initialized automatically from Config.toml (e.g., INFO)
+
+// Create a logger via fromConfig — this is a child of the root logger
 log:Logger paymentLogger = check log:fromConfig(id = "payment-service", level = log:INFO);
 
 // Create child loggers with additional context
@@ -120,119 +375,40 @@ paymentLogger.printInfo("Payment processed");
 orderLogger.printInfo("Order created");
 refundLogger.printInfo("Refund initiated");
 
-// When ICP changes "payment-service" to DEBUG level,
-// orderLogger and refundLogger will also log at DEBUG level
+// Change parent level — affects child loggers that haven't set their own level
+paymentLogger.setLevel(log:DEBUG);
+orderLogger.getLevel();   // DEBUG (inherited from parent)
+refundLogger.getLevel();  // DEBUG (inherited from parent)
+
+// Set an independent level on a child logger
+orderLogger.setLevel(log:ERROR);
+orderLogger.getLevel();   // ERROR (explicit override)
+refundLogger.getLevel();  // DEBUG (still inherited from parent)
+
+// Parent changes no longer affect orderLogger (has explicit level)
+paymentLogger.setLevel(log:WARN);
+orderLogger.getLevel();   // ERROR (still explicit)
+refundLogger.getLevel();  // WARN (inherited from parent)
 ```
 
-### Java APIs
+### Backward Compatibility
 
-The following Java APIs are provided in `io.ballerina.stdlib.log.LogConfigManager` for ICP agent integration:
+This proposal maintains backward compatibility for the most common use cases. All existing root logger and child logger usage continues to work unchanged:
 
-#### Get Current Configuration
+```ballerina
+// Existing usage - unchanged
+log:printInfo("Hello World!");
 
-```java
-/**
- * Get the current log configuration.
- *
- * @return BMap containing:
- *   - "rootLogger": map with "level" key containing the root log level
- *   - "modules": map of module name -> map with "level" key
- *   - "customLoggers": map of logger ID -> map with "level" key (only user-named loggers)
- */
-public static BMap<BString, Object> getLogConfig();
+// Existing custom logger - unchanged
+log:Logger myLogger = check log:fromConfig(level = log:DEBUG);
+myLogger.printInfo("Custom logger message");
 ```
 
-#### Root Log Level Management
-
-```java
-/**
- * Get the current global root log level.
- *
- * @return the root log level as BString
- */
-public static BString getGlobalLogLevel();
-
-/**
- * Set the global root log level.
- *
- * @param level the new log level (DEBUG, INFO, WARN, ERROR)
- * @return null on success, BError on invalid level
- */
-public static Object setGlobalLogLevel(BString level);
-```
-
-#### Module Log Level Management
-
-```java
-/**
- * Set or update a module's log level.
- *
- * @param moduleName the fully qualified module name (e.g., "myorg/mymodule")
- * @param level the new log level
- * @return null on success, BError on invalid level
- */
-public static Object setModuleLevel(BString moduleName, BString level);
-
-/**
- * Remove a module's log level configuration.
- * After removal, the module will use the root log level.
- *
- * @param moduleName the module name
- * @return true if removed, false if not found
- */
-public static boolean removeModuleLevel(BString moduleName);
-```
-
-#### Custom Logger Management
-
-```java
-/**
- * Set a custom logger's log level.
- * Only works for loggers created with an explicit ID.
- *
- * @param loggerId the logger ID provided during creation
- * @param level the new log level
- * @return null on success, BError if logger not found or invalid level
- */
-public static Object setLoggerLevel(BString loggerId, BString level);
-```
-
-### Configuration Response Structure
-
-The `getLogConfig()` method returns a map with the following nested structure. This design allows for future extensibility to include additional configuration properties (like log context) without breaking the existing contract:
-
-```json
-{
-  "rootLogger": {
-    "level": "INFO"
-  },
-  "modules": {
-    "myorg/payment": {
-      "level": "DEBUG"
-    },
-    "myorg/notification": {
-      "level": "WARN"
-    }
-  },
-  "customLoggers": {
-    "payment-service": {
-      "level": "INFO"
-    },
-    "audit-logger": {
-      "level": "DEBUG"
-    }
-  }
-}
-```
-
-Note: Only custom loggers created with an explicit `id` appear in the `customLoggers` map.
+The only breaking change is for developers who have implemented the `Logger` interface from scratch — they must add `getLevel` and `setLevel` method implementations.
 
 ### Thread Safety
 
-All runtime configuration changes are thread-safe:
-- Root log level uses `AtomicReference<String>`
-- Module log levels use `ConcurrentHashMap<String, String>`
-- Custom logger levels use `ConcurrentHashMap<String, String>`
+All runtime configuration changes are thread-safe. The internal logger registry and level modifications use Ballerina's `isolated` guarantees to ensure safe concurrent access.
 
 ### Log Level Validation
 
@@ -243,19 +419,23 @@ All set operations validate the log level and return an error for invalid values
 ### Capabilities Summary
 
 **Can Do:**
+- Retrieve and set log levels programmatically via `getLevel()` / `setLevel()` on any logger instance
+- Set independent level overrides on child loggers
 - Adjust the global root logger's log level
-- Add new module-level log configurations
-- Update existing module-level log configurations
-- Remove specific module-level log configurations
-- Modify log levels for custom loggers created with an explicit `id` via `fromConfig` API
+- Discover and manage all registered loggers via `LoggerRegistry` (`getDetails()`, `getById()`, `setLevel()`)
+- Differentiate logger behaviour at runtime via `kind` (`root`, `module`, `custom`, `child`) in `LoggerInfo`
+- Modify log levels for module loggers (configured in `Config.toml`) via ICP, using the module name as the logger ID
+- Modify log levels for all loggers created via `fromConfig` API (with explicit or auto-generated IDs) via ICP
+- Modify log levels for child loggers created via `withContext` via ICP
 
-**Cannot Do:**
-- Modify log levels for custom loggers created without an `id`
+**Cannot Do (Initial Phase):**
+- Reset a child logger's level to inherit from its parent (`resetLevel`) — deferred to future phase along with parent-child tree tracking in the registry
+- Modify log levels dynamically for custom loggers created by implementing the `Logger` interface from scratch (future enhancement)
 - Modify other logger configurations (format, destinations) at runtime
-- Access or modify loggers created directly using the `Logger` interface (not via `fromConfig`)
 
 ## Future Considerations
 
-- Support for modifying log format at runtime
-- Support for adding/removing destinations at runtime
-- Ballerina-level public APIs for runtime log modification (if needed beyond ICP)
+- Add `resetLevel(string id)` to `LoggerRegistry` — requires parent-child tree tracking in the registry. This will allow resetting a child logger's level to inherit from its parent, similar to Java's `setLevel(null)` and Python's `setLevel(NOTSET)`.
+- Support dynamic log level changes for custom loggers (created by implementing the `Logger` interface from scratch).
+- Support for modifying log format at runtime.
+- Support for adding/removing destinations at runtime.


### PR DESCRIPTION
## Purpose
This proposal introduces Java APIs to modify log levels at runtime without application restart. The primary goal is to enable the WSO2 Integrator: ICP (Integration Control Plane) dashboard to dynamically adjust the root logger level, module-specific log levels, and custom loggers' levels created via the `fromConfig` API.

Library issue: https://github.com/ballerina-platform/ballerina-library/issues/6213
Spec issue: https://github.com/ballerina-platform/ballerina-spec/issues/1424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds native APIs to enable dynamic runtime modification of log levels, allowing operators and management tools (e.g., WSO2 Integrator ICP) to adjust logging behavior without restarting applications. The change improves operational control for broad or targeted logging adjustments and supports discovery and programmatic control of loggers at runtime.

## Changes

- Logger interface
  - Added public isolated function getLevel() returns Level to obtain a logger's current level.
  - Added public isolated function setLevel(Level) returns error? to change a logger's level at runtime.

- Logger registry and discovery
  - Introduced public isolated class LoggerRegistry with:
    - getIds() returns string[] to list registered logger identifiers.
    - getById(string) returns Logger? to retrieve a logger by identifier.
    - setLevel(string, Level) returns error? to update a logger's level by identifier.
  - Added public isolated function getLoggerRegistry() returns LoggerRegistry to obtain the registry.

- Types and metadata
  - Added public type LoggerKind = "root" | "module" | "custom" | "child" for logger categorization.
  - Added public readonly type LoggerInfo with fields Level level and LoggerKind kind to expose logger metadata.

- Configuration
  - Extended public type Config record with optional string id? for explicit logger identification.
  - Documented auto-generated IDs when id is omitted, module-prefixed IDs for module loggers, and guidance for avoiding ID collisions.

- Behavior and guarantees
  - Child loggers inherit levels from parents and are not independently configurable via the registry.
  - Thread-safe operations and case-insensitive level parsing with validation against allowed levels are specified.
  - Backward-compatibility note: changes are additive for most users; custom loggers implementing Logger may require updates to support the new methods.

## Impact

Operators and management tools can:
- Adjust the root logger level for broad change in logging verbosity.
- Modify module-specific logger levels for targeted diagnostics.
- Control levels of custom loggers created via configuration.
- Discover registered loggers and inspect or change their current settings via the LoggerRegistry.

Lines changed: +368
<!-- end of auto-generated comment: release notes by coderabbit.ai -->