### PR TITLE
docs: fix duplicated word in regexp split doc comment

### DIFF
--- a/lang/lib/regexp.bal
+++ b/lang/lib/regexp.bal
@@ -144,7 +144,7 @@ public isolated function replace(RegExp re, string str, Replacement replacement,
 public isolated function replaceAll(RegExp re, string str, Replacement replacement, int startIndex = 0) returns string = external;
 
 # Splits a string into substrings separated by matches of a regular expression.
-# This finds the the non-overlapping matches of a regular expression and
+# This finds the non-overlapping matches of a regular expression and
 # returns a list of substrings of `str` that occur before the first match,
 # between matches, or after the last match.  If there are no matches, then
 # `[str]` will be returned.


### PR DESCRIPTION
## Purpose
Same duplicated word as in ballerina-lang's langlib/lang.regexp/src/main/ballerina/regexp.bal, fixed here per @MaryamZi's request on that PR. The doc comment for regexp:split() reads "This finds the the non-overlapping matches...", with "the" duplicated.

## Approach
Single-line text edit removing the duplicate word from the doc comment. No code, logic, or behavior changes.

## Samples
Not applicable, it's a documentation text fix only, no new or changed samples.

## Remarks
Companion fix to <link the ballerina-lang PR here> for the same typo.

## Check List
- [x] Read the Contributing Guide
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage
- [ ] Added necessary documentation
  - [ ] API documentation
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples

Corrected a duplicated word in the regexp:split() specification doc comment, matching the fix already approved in ballerina-lang. This documentation-only change does not affect functionality, APIs, samples, or tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the `regexp:split()` documentation to remove a duplicated word and improve clarity. No code, API, behavior, or tests were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->