### PR TITLE
Add BEP for post-processing actions in the local file listener

### DIFF
--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -86,15 +86,15 @@ The action runs after the remote function returns. When several services are att
 
 For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
 
-The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory, with symbolic links resolved. `moveTo` is not relative to the watched directory.
+The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory. For the attach-time checks below, symbolic links in the listener's `path` and in `moveTo` are resolved first. The action operates on the event's file path as delivered and does not follow symbolic links.
 
 Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, when the listener is recursive and `moveTo` is inside the watched directory, or when another service on the listener already configures an action for the same remote function. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
 
-Only regular files are acted on. A create event for a new subdirectory invokes the remote function but skips the action.
+Only regular files are acted on. Directories and symbolic links are skipped: a create event for a new subdirectory or for a link invokes the remote function but skips the action.
 
 A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped.
 
-Moving or deleting the file emits a delete event for the source path. Every service attached to the listener receives it, and `onDelete` is invoked where declared.
+Removing the file from the watched directory, by `DELETE` or by `MOVE`, produces a delete event from the file system like any other removal. The listener generates no events of its own. Every service attached to the listener receives that event, and `onDelete` is invoked where declared. If the source file remains, no delete event occurs.
 
 When several services are attached to the same listener, every service handles the event before the action runs, so each remote function sees the file in place.
 
@@ -175,7 +175,7 @@ service on fileListener {
 4. `DELETE` and `MOVE` after `onCreate` returns an error, and after it panics.
 5. Only one of `afterProcess` and `afterError` runs when both are set.
 6. A destination file that already exists causes the move to fail and leaves the source in place.
-7. A directory create event runs the remote function but skips the action.
+7. A create event for a directory or for a symbolic link runs the remote function but skips the action.
 8. The action is skipped without error when the remote function has already moved the file.
 9. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
 10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, for `moveTo` inside a recursively watched directory, and for a second service configuring an action for the same remote function on the same listener. Attach succeeds for a subdirectory of a non-recursive watched directory.
@@ -185,7 +185,7 @@ service on fileListener {
 
 ## Risks and Assumptions
 
-- A create event is emitted when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
+- A create event arrives when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
 - A move across file systems is a copy followed by a delete and is not atomic. If the copy fails, no partial destination is left and the source stays in place. On Windows, if the copy succeeds but the source cannot be deleted, both files remain.
 - The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
 - A listener whose services carry no annotation is unaffected.

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -175,7 +175,7 @@ service on fileListener {
 6. A destination file that already exists causes the move to fail and leaves the source in place.
 7. A directory create event runs the remote function but skips the action.
 8. The action is skipped without error when the remote function has already moved the file.
-9. `onDelete` is invoked for the delete event caused by an action.
+9. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
 10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, and for `moveTo` inside a recursively watched directory. Attach succeeds for a subdirectory of a non-recursive watched directory.
 11. Two services with actions on the same event: the file is acted on once and neither service fails.
 12. A listener whose services carry no annotation behaves as before.
@@ -184,7 +184,7 @@ service on fileListener {
 ## Risks and Assumptions
 
 - A create event is emitted when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
-- A move across file systems is a copy followed by a delete and is not atomic.
+- A move across file systems is a copy followed by a delete and is not atomic. If the copy fails, no partial destination is left and the source stays in place. On Windows, if the copy succeeds but the source cannot be deleted, both files remain.
 - The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
 - A listener whose services carry no annotation is unaffected.
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -3,13 +3,13 @@
 - Authors - @YasanPunch
 - Reviewed by -
 - Created date - 2026/09/10
-- Updated date - 2026/09/10
+- Updated date - 2026/09/11
 - Issue - [#1501](https://github.com/ballerina-platform/ballerina-spec/issues/1501)
 - State - Submitted
 
 ## Summary
 
-Add a `@file:FunctionConfig` annotation to the `ballerina/file` module. A remote function of a file service uses it to declare what happens to the file after the function completes: delete it, or move it to another directory. Separate actions can be set for success and for error. The annotation has the same shape as the `afterProcess` and `afterError` fields of `@ftp:FunctionConfig`.
+Add a `@file:FunctionConfig` annotation to the `ballerina/file` module. A remote function of a file service uses it to declare what happens to the file after the function completes: delete it, or move it to another directory. Separate actions can be set for success and for error. Its `afterProcess` and `afterError` fields have the same shape as those of `@ftp:FunctionConfig`.
 
 ## Motivation
 
@@ -74,29 +74,37 @@ The annotation is valid on `onCreate` and `onModify` only. Attaching it to `onDe
 
 On one listener, only one service may configure an action for a given remote function. A second service declaring an action for the same remote function on the same listener is a compile-time error. Attaching such a service at runtime fails with an error.
 
+Different services on one listener may configure different remote functions. An annotation with either field set configures its remote function. An annotation with neither field set is allowed and configures nothing. After a service is detached, another service may configure that remote function. The compile-time check covers services declared on the same listener in one module; other services are checked when they are attached.
+
 ### 3. Behavior
 
-When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. At most one action runs per invocation. If the relevant field is not set, the file is left in place.
+**Outcome.** When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. At most one action runs per invocation. If the relevant field is not set, the file is left in place. Only the outcome of the remote function that carries the annotation selects the action.
 
-The action runs after the remote function returns. When several services are attached to the listener, it runs after every service has handled the event.
+**When the action runs.** The action runs after the remote function returns. When several services are attached to the listener, it runs after every service has handled the event. Actions for events already dispatched run to completion after the listener stops.
 
-`DELETE` removes the file.
+**`DELETE`.** The file is removed.
 
-`MOVE` moves the file into the `moveTo` directory. With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. With `false`, the file is placed directly in `moveTo` under its own name. Missing directories on the destination path are created. If a file with the same name already exists at the destination, the move fails, the failure is logged, and the source file stays in place.
+**`MOVE`.** The file is moved into the `moveTo` directory. With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. With `false`, the file is placed directly in `moveTo` under its own name, and files with the same name from different subdirectories collide there. On a non-recursive listener, `preserveSubDirs` has no effect. Directories missing on the destination path are created when the action runs; if they cannot be created, the action fails and is logged. If an entry with the destination name already exists, the move fails, the failure is logged, and the source file stays in place. If the computed destination is inside a recursively watched directory, the move fails and is logged.
 
 For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
 
-The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory. For the attach-time checks below, symbolic links in the listener's `path` and in `moveTo` are resolved first. The action operates on the event's file path as delivered and does not follow symbolic links.
+**Paths.** The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory. For the attach-time checks, symbolic links in the listener's `path` and in `moveTo` are resolved first. The action uses the event's file path as delivered: links in parent directories are traversed, and a link as the final path component is skipped.
 
-Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, when the listener is recursive and `moveTo` is inside the watched directory, or when another service on the listener already configures an action for the same remote function. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
+**Attach-time checks.** Attaching a service fails with an error when the annotation is present on `onDelete`, when `moveTo` is empty, when `moveTo` exists and is not a directory, when `moveTo` is the watched directory, when the listener is recursive and `moveTo` is inside the watched directory, or when another service on the listener already configures an action for the same remote function. With `recursive: false`, a subdirectory of the watched directory such as `/data/in/processed` is a valid destination; creating it produces a create event for the directory, which invokes the remote function and skips the action.
 
-Only regular files are acted on. Directories and symbolic links are skipped: a create event for a new subdirectory or for a link invokes the remote function but skips the action.
+**What is acted on.** Only regular files are acted on. Directories and symbolic links are skipped: a create event for a new subdirectory or for a link invokes the remote function but skips the action. The action acts on the regular file at the path when it runs, whether or not it is the file that produced the event.
 
-A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped.
+**Failures.** A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped. On Windows, a file still open by another process cannot be moved or deleted; the action fails and is logged.
 
-Removing the file from the watched directory, by `DELETE` or by `MOVE`, produces a delete event from the file system like any other removal. The listener generates no events of its own. Every service attached to the listener receives that event, and `onDelete` is invoked where declared. If the source file remains, no delete event occurs.
+**Events produced.** Removing the file from the watched directory, by `DELETE` or by `MOVE`, produces a delete event from the file system like any other removal. The listener generates no events of its own. Every service attached to the listener receives that event, and `onDelete` is invoked where declared. If the source file remains, no delete event occurs.
 
-When several services are attached to the same listener, every service handles the event before the action runs, so each remote function sees the file in place.
+**Several events on one file.** Each event is a separate invocation with its own action. Events for the same file are handled independently and may run concurrently. A remote function for a later event may find the file already removed by an earlier event's action; its own action is then skipped.
+
+**Several services on one listener.** Within one event, every service handles the event before the action runs.
+
+**Several listeners on one directory.** Each listener acts independently. The later action finds the file gone and is skipped.
+
+**Other services.** On a service that is not attached to a `file:Listener`, the annotation has no effect.
 
 ### 4. Usage examples
 
@@ -173,21 +181,31 @@ service on fileListener {
 2. `MOVE` after a successful `onCreate` places the file under `moveTo`, creating missing directories.
 3. `MOVE` with `preserveSubDirs: true` on a recursive listener keeps the subdirectory path; with `false` it does not.
 4. `DELETE` and `MOVE` after `onCreate` returns an error, and after it panics.
-5. Only one of `afterProcess` and `afterError` runs when both are set.
-6. A destination file that already exists causes the move to fail and leaves the source in place.
-7. A create event for a directory or for a symbolic link runs the remote function but skips the action.
-8. The action is skipped without error when the remote function has already moved the file.
-9. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
-10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, for `moveTo` inside a recursively watched directory, and for a second service configuring an action for the same remote function on the same listener. Attach succeeds for a subdirectory of a non-recursive watched directory.
-11. Two services on one listener, one with an action on `onCreate` and one without: both remote functions run with the file in place, then the file is acted on once.
-12. A listener whose services carry no annotation behaves as before.
-13. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, rejected on a second service configuring the same remote function on the same listener, recognised through an import alias, and a user-defined annotation with the same name is not flagged.
+5. `DELETE` and `MOVE` on `onModify` after success, after an error, and after a panic.
+6. Only one of `afterProcess` and `afterError` runs when both are set.
+7. An entry that already exists at the destination causes the move to fail and leaves the source in place.
+8. A create event for a directory or for a symbolic link runs the remote function but skips the action.
+9. The action is skipped without error when the remote function has already moved the file.
+10. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
+11. Attach fails for the annotation on `onDelete`, for an empty `moveTo`, for a `moveTo` that exists and is not a directory, for `moveTo` equal to the watched directory, for `moveTo` inside a recursively watched directory, for a `moveTo` symbolic link that points into a recursively watched directory, and for a second service configuring the same remote function on the same listener.
+12. Attach succeeds for a subdirectory of a non-recursive watched directory. The first move creates it; the directory create event runs the remote function and skips the action.
+13. A relative `moveTo` resolves against the working directory.
+14. A computed destination inside a recursively watched directory fails and is logged.
+15. An action failure other than a collision, such as `DELETE` in a directory without write permission, is logged and leaves the file in place.
+16. A file that produces a create event and a modify event, both with actions: the first action removes the file and the second is skipped.
+17. Two services on one listener, one with an action on `onCreate` and one without: both remote functions run with the file in place, then the file is acted on once.
+18. An annotation with neither field set is accepted and configures nothing.
+19. After a service is detached, another service can configure the same remote function.
+20. A listener whose services carry no annotation behaves as before.
+21. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, rejected on a second service configuring the same remote function on the same listener, recognized through an import alias, and a user-defined annotation with the same name is not flagged.
+
+Moves across file systems are not covered by automated tests.
 
 ## Risks and Assumptions
 
-- A create event arrives when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
-- A move across file systems is a copy followed by a delete and is not atomic. If the copy fails, no partial destination is left and the source stays in place. On Linux and macOS, if the copy succeeds but the source cannot be deleted, the copy is removed and the source stays in place. On Windows, both files remain in that case, and a later action on the same file follows the collision rule: the move fails and the source stays in place.
-- The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
+- A create event may arrive before the writer has finished, and each write may produce a further modify event. This proposal assumes each file is complete when its event is delivered. Producers write the file outside the watched directory, on the same file system, and move it into the watched directory when complete.
+- A move across file systems is a copy followed by a delete and is not atomic. On Linux and macOS, if the copy fails, no partial destination is left and the source stays in place; if the copy succeeds but the source cannot be deleted, the copy is removed and the source stays in place. On Windows, if the copy succeeds but the source cannot be deleted, both files remain, and a later action on the same file follows the collision rule.
+- The process needs write permission on the directory containing the file, on `moveTo`, and on any directory it creates under `moveTo`.
 - A listener whose services carry no annotation is unaffected.
 
 ## Dependencies
@@ -198,7 +216,7 @@ None. The low-code trigger metadata shipped with the module is updated in the sa
 
 - File name filtering on the listener, tracked in [ballerina-library#8748](https://github.com/ballerina-platform/ballerina-library/issues/8748).
 - Age-based file filtering, matching the FTP listener's `fileAgeFilter`.
-- Content-binding remote functions for the file listener. The annotation applies to them without change.
+- Content-binding remote functions for the file listener. Extending the annotation to them extends the list of remote functions it is valid on.
 
 ## References
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -72,11 +72,13 @@ public annotation FunctionConfiguration FunctionConfig on service remote functio
 
 The annotation is valid on `onCreate` and `onModify` only. Attaching it to `onDelete` is a compile-time error. Attaching such a service to a listener at runtime fails with an error.
 
+On one listener, only one service may configure an action for a given remote function. A second service declaring an action for the same remote function on the same listener is a compile-time error. Attaching such a service at runtime fails with an error.
+
 ### 3. Behavior
 
 When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. At most one action runs per invocation. If the relevant field is not set, the file is left in place.
 
-The action runs as soon as the remote function returns.
+The action runs after the remote function returns. When several services are attached to the listener, it runs after every service has handled the event.
 
 `DELETE` removes the file.
 
@@ -86,7 +88,7 @@ For example, the listener watches `/data/in` with `recursive: true`, and `/data/
 
 The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory, with symbolic links resolved. `moveTo` is not relative to the watched directory.
 
-Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, or when the listener is recursive and `moveTo` is inside the watched directory. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
+Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, when the listener is recursive and `moveTo` is inside the watched directory, or when another service on the listener already configures an action for the same remote function. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
 
 Only regular files are acted on. A create event for a new subdirectory invokes the remote function but skips the action.
 
@@ -94,7 +96,7 @@ A failure of the action itself is logged and is not reported to the service. The
 
 Moving or deleting the file emits a delete event for the source path. Every service attached to the listener receives it, and `onDelete` is invoked where declared.
 
-When several services are attached to the same listener, a remote function of one service may run after an action of another service has already moved or deleted the file. The first action to run acts on the file and the others are skipped.
+When several services are attached to the same listener, every service handles the event before the action runs, so each remote function sees the file in place.
 
 ### 4. Usage examples
 
@@ -176,10 +178,10 @@ service on fileListener {
 7. A directory create event runs the remote function but skips the action.
 8. The action is skipped without error when the remote function has already moved the file.
 9. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
-10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, and for `moveTo` inside a recursively watched directory. Attach succeeds for a subdirectory of a non-recursive watched directory.
-11. Two services with actions on the same event: the file is acted on once and neither service fails.
+10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, for `moveTo` inside a recursively watched directory, and for a second service configuring an action for the same remote function on the same listener. Attach succeeds for a subdirectory of a non-recursive watched directory.
+11. Two services on one listener, one with an action on `onCreate` and one without: both remote functions run with the file in place, then the file is acted on once.
 12. A listener whose services carry no annotation behaves as before.
-13. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, recognised through an import alias, and a user-defined annotation with the same name is not flagged.
+13. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, rejected on a second service configuring the same remote function on the same listener, recognised through an import alias, and a user-defined annotation with the same name is not flagged.
 
 ## Risks and Assumptions
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -9,29 +9,26 @@
 
 ## Summary
 
-Add a `@file:FunctionConfig` annotation to the `ballerina/file` module. A remote function of a file service uses it to declare what happens to the file after the function completes: delete it, or move it to another directory. Separate actions can be set for success and for error. Its `afterProcess` and `afterError` fields have the same shape as those of `@ftp:FunctionConfig`.
+Add a `@file:FunctionConfig` annotation to the `ballerina/file` module. A remote function of a file service uses it to declare what happens to the file after the function completes: delete it, or move it to another directory, with separate actions for success and for error. The fields match `afterProcess` and `afterError` of `@ftp:FunctionConfig`.
 
 ## Motivation
 
-A `file:Listener` invokes `onCreate`, `onModify`, and `onDelete` for changes in a watched directory. After a remote function has processed a file, the file stays where it is. Users move or delete it themselves at the end of each remote function, and again on the error path.
+A `file:Listener` invokes `onCreate`, `onModify`, and `onDelete` for changes in a watched directory. After a remote function has processed a file, the file stays where it is. Users move or delete it themselves in every remote function, and again on the error path.
 
 The `ftp:Listener` already provides this through `@ftp:FunctionConfig`. Users who build integrations with both listeners, including through the WSO2 Integrator low-code editor, expect the same options in both.
 
 ## Goals
 
-- Run an action after a remote function returns successfully.
-- Run a separate action after a remote function returns an error or panics.
-- Support `DELETE` and `MOVE` actions.
-- Use the same annotation name as `@ftp:FunctionConfig`, and the same names and value shapes for its `afterProcess` and `afterError` fields.
-- Keep listeners whose services carry no annotation unchanged.
+- Run an action after a remote function returns successfully, and a separate action after it returns an error or panics.
+- Support `DELETE` and `MOVE`.
+- Use the same annotation name and the same `afterProcess` and `afterError` shapes as `@ftp:FunctionConfig`.
+- Leave services without the annotation unchanged.
 
 ## Non-Goals
 
-- File name filtering on the listener or on the annotation.
+- File name filtering.
 - Age-based file filtering, as offered by the FTP listener's `fileAgeFilter`.
-- An `onError` remote function for the file service.
-- Content-binding remote functions such as `onFileJson` for the file listener.
-- Chained or conditional actions.
+- An `onError` remote function or content-binding remote functions for the file listener.
 
 ## Design
 
@@ -70,52 +67,24 @@ public type FunctionConfiguration record {|
 public annotation FunctionConfiguration FunctionConfig on service remote function;
 ```
 
-The annotation is valid on `onCreate` and `onModify` only. Attaching it to `onDelete` is a compile-time error. Attaching such a service to a listener at runtime fails with an error.
-
-On one listener, only one service may configure an action for a given remote function. A second service declaring an action for the same remote function on the same listener is a compile-time error. Attaching such a service at runtime fails with an error.
-
-Different services on one listener may configure different remote functions. An annotation with either field set configures its remote function. An annotation with neither field set is allowed and configures nothing. After a service is detached, another service may configure that remote function. The compile-time check covers services declared on the same listener in one module; other services are checked when they are attached.
+The annotation is valid on `onCreate` and `onModify`. On `onDelete` it is a compile-time error. On one listener, only one service may configure an action for a given remote function; a second one is a compile-time error. Both rules are also checked when a service is attached at runtime.
 
 ### 3. Behavior
 
-**Outcome.** When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. At most one action runs per invocation. If the relevant field is not set, the file is left in place. Only the outcome of the remote function that carries the annotation selects the action.
+**After a successful return:** the `afterProcess` action runs.
 
-**When the action runs.** The action runs after the remote function returns. When several services are attached to the listener, it runs after every service has handled the event. Actions for events already dispatched run to completion after the listener stops.
+**After an error or panic:** the error is printed, then the `afterError` action runs.
 
-**`DELETE`.** The file is removed.
+If the relevant field is not set, the file stays in place. The action runs after the remote function returns. When several services are attached to the listener, it runs after every service has handled the event.
 
-**`MOVE`.** The file is moved into the `moveTo` directory.
-- With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. On a non-recursive listener the flag has no effect.
-- With `false`, the file is placed directly in `moveTo` under its own name; files with the same name from different subdirectories collide there.
-- Directories missing on the destination path are created when the action runs. If they cannot be created, the action fails and is logged.
-- If an entry with the destination name already exists, the move fails, the failure is logged, and the source file stays in place.
-- If the computed destination is inside a recursively watched directory, the move fails and is logged.
+- `DELETE`: the file is removed.
+- `MOVE`: the file is moved into the `moveTo` directory. With `preserveSubDirs` set to `true`, the default, it keeps its path relative to the listener's `path`; with `false`, it is placed directly in `moveTo`. Missing directories are created. If an entry with the destination name already exists, the move fails and the source stays in place.
 
-For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
+Paths are resolved to absolute paths against the working directory; `moveTo` is not relative to the watched directory. Attaching a service fails when `moveTo` is empty, is the watched directory, or, on a recursive listener, is inside it. A move whose computed destination is inside a recursively watched directory fails. With `recursive: false`, a subdirectory such as `/data/in/processed` is a valid destination.
 
-**Paths.** The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory. For the attach-time checks, symbolic links in the listener's `path` and in `moveTo` are resolved first. The action uses the event's file path as delivered: links in parent directories are traversed, and a link as the final path component is skipped.
+Only regular files are acted on; directories and symbolic links are skipped. A failure of the action is logged and is not reported to the service; the file stays in place. If the file is no longer present when the action runs, the action is skipped. Removing the file produces a delete event like any other removal, and `onDelete` runs in every attached service that declares it.
 
-**Attach-time checks.** Attaching a service fails with an error when:
-- the annotation is present on `onDelete`;
-- `moveTo` is empty, or exists and is not a directory;
-- `moveTo` is the watched directory, or the listener is recursive and `moveTo` is inside it;
-- another service on the listener already configures an action for the same remote function.
-
-With `recursive: false`, a subdirectory of the watched directory such as `/data/in/processed` is a valid destination. Creating it produces a create event for the directory, which invokes the remote function and skips the action.
-
-**What is acted on.** Only regular files are acted on. Directories and symbolic links are skipped: a create event for a new subdirectory or for a link invokes the remote function but skips the action. The action acts on the regular file at the path when it runs, whether or not it is the file that produced the event.
-
-**Failures.** A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped. On Windows, a file still open by another process cannot be moved or deleted; the action fails and is logged.
-
-**Events produced.** Removing the file from the watched directory, by `DELETE` or by `MOVE`, produces a delete event from the file system like any other removal. The listener generates no events of its own. Every service attached to the listener receives that event, and `onDelete` is invoked where declared. If the source file remains, no delete event occurs.
-
-**Several events on one file.** Each event is a separate invocation with its own action. Events for the same file are handled independently and may run concurrently. A remote function for a later event may find the file already removed by an earlier event's action; its own action is then skipped.
-
-**Several services on one listener.** Within one event, every service handles the event before the action runs.
-
-**Several listeners on one directory.** Each listener acts independently. The later action finds the file gone and is skipped.
-
-**Other services.** On a service that is not attached to a `file:Listener`, the annotation has no effect.
+**Example:** the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`; with `false`, at `/data/archive/a.csv`.
 
 ### 4. Usage examples
 
@@ -161,26 +130,6 @@ service on fileListener {
 }
 ```
 
-#### Example 4: Different actions for create and modify
-
-```ballerina
-service on fileListener {
-    @file:FunctionConfig {
-        afterProcess: {moveTo: "/data/archive"}
-    }
-    remote function onCreate(file:FileEvent event) returns error? {
-        check importNew(event.name);
-    }
-
-    @file:FunctionConfig {
-        afterError: {moveTo: "/data/failed"}
-    }
-    remote function onModify(file:FileEvent event) returns error? {
-        check reimport(event.name);
-    }
-}
-```
-
 ## Alternatives
 
 - Manual handling in each remote function. Rejected: this is the boilerplate the feature removes.
@@ -188,25 +137,21 @@ service on fileListener {
 
 ## Testing
 
-1. `DELETE` and `MOVE` after success, after an error, and after a panic, on `onCreate` and on `onModify`; only one of the two actions runs when both are set.
-2. `preserveSubDirs` `true` and `false` on a recursive listener; no effect on a non-recursive listener.
-3. Missing destination directories are created; an existing entry at the destination fails the move; a computed destination inside a recursively watched directory fails the move.
-4. Directory and symbolic-link events skip the action; a file already moved by the remote function skips the action; an action failure such as `DELETE` without write permission is logged and leaves the file in place.
-5. The delete event caused by an action reaches every attached service, including one with no annotation.
-6. Each attach-time rejection listed under Behavior, and success for a subdirectory of a non-recursive watched directory, including the create event for that directory.
-7. Two services on one listener, one with an action and one without; a create followed by a modify event on one file; two listeners on one directory.
-8. An annotation with neither field set; detach and re-attach of the configuring service; a relative `moveTo`.
-9. A listener whose services carry no annotation behaves as before.
-10. Compiler plugin: accepted on `onCreate` and `onModify`, rejected on `onDelete` and on a second service configuring the same remote function on the same listener, recognized through an import alias, and a user-defined annotation with the same name is not flagged.
-
-Moves across file systems are not covered by automated tests.
+1. `DELETE` and `MOVE` after success, error, and panic, on `onCreate` and on `onModify`.
+2. `preserveSubDirs` `true` and `false` on a recursive listener; missing directories created; an existing destination fails the move.
+3. Directory and symbolic-link events, and a file already gone, skip the action; an action failure is logged and leaves the file in place.
+4. `onDelete` runs in every attached service for the delete event caused by an action.
+5. Attach rejections: annotation on `onDelete`, empty `moveTo`, `moveTo` equal to or inside the watched directory, a second service on the same remote function; success for a subdirectory of a non-recursive watched directory.
+6. Two services on one listener, one with an action; a create followed by a modify event on one file.
+7. A listener without annotations behaves as before.
+8. Compiler plugin: accepted on `onCreate` and `onModify`, rejected on `onDelete` and on a second service, recognized through an import alias, and a user-defined annotation with the same name is not flagged.
 
 ## Risks and Assumptions
 
-- A create event may arrive before the writer has finished, and each write may produce a further modify event. This proposal assumes each file is complete when its event is delivered. Producers write the file outside the watched directory, on the same file system, and move it into the watched directory when complete.
-- A move across file systems is a copy followed by a delete and is not atomic. On Linux and macOS, a failed copy leaves no partial destination. A failed source delete after a successful copy removes the copy. The source stays in place in both cases. On Windows, if the copy succeeds but the source cannot be deleted, both files remain, and a later action on the same file follows the collision rule.
-- The process needs write permission on the directory containing the file, on `moveTo`, and on any directory it creates under `moveTo`.
-- A listener whose services carry no annotation is unaffected.
+- A create event can arrive before the writer has finished. The proposal assumes each file is complete when its event is delivered: producers write outside the watched directory on the same file system and move the finished file in.
+- The action acts on whatever regular file is at the path when it runs.
+- A move across file systems is a copy followed by a delete and is not atomic; a failed step leaves the source in place, and on Windows can also leave the copy. On Windows an open file cannot be moved or deleted.
+- Services without the annotation are unaffected.
 
 ## Dependencies
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -186,7 +186,7 @@ service on fileListener {
 ## Risks and Assumptions
 
 - A create event arrives when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
-- A move across file systems is a copy followed by a delete and is not atomic. If the copy fails, no partial destination is left and the source stays in place. On Windows, if the copy succeeds but the source cannot be deleted, both files remain.
+- A move across file systems is a copy followed by a delete and is not atomic. If the copy fails, no partial destination is left and the source stays in place. On Linux and macOS, if the copy succeeds but the source cannot be deleted, the copy is removed and the source stays in place. On Windows, both files remain in that case, and a later action on the same file follows the collision rule: the move fails and the source stays in place.
 - The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
 - A listener whose services carry no annotation is unaffected.
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -1,0 +1,205 @@
+# 1501: Post-Processing Actions for the File Listener
+
+- Authors - @YasanPunch
+- Reviewed by -
+- Created date - 2026/09/10
+- Updated date - 2026/09/10
+- Issue - [#1501](https://github.com/ballerina-platform/ballerina-spec/issues/1501)
+- State - Submitted
+
+## Summary
+
+Add a `@file:FunctionConfig` annotation to the `ballerina/file` module. A remote function of a file service uses it to declare what happens to the file after the function completes: delete it, or move it to another directory. Separate actions can be set for success and for error. The annotation has the same shape as the `afterProcess` and `afterError` fields of `@ftp:FunctionConfig`.
+
+## Motivation
+
+A `file:Listener` invokes `onCreate`, `onModify`, and `onDelete` for changes in a watched directory. After a remote function has processed a file, the file stays where it is. Users move or delete it themselves at the end of each remote function, and again on the error path.
+
+The `ftp:Listener` already provides this through `@ftp:FunctionConfig`. Users who build integrations with both listeners, including through the WSO2 Integrator low-code editor, expect the same options in both.
+
+## Goals
+
+- Run an action after a remote function returns successfully.
+- Run a separate action after a remote function returns an error or panics.
+- Support `DELETE` and `MOVE` actions.
+- Use the same annotation name, field names, and value shapes as `@ftp:FunctionConfig`.
+- Keep services without the annotation unchanged.
+
+## Non-Goals
+
+- File name filtering on the listener or on the annotation.
+- Age-based file filtering, as offered by the FTP listener's `fileAgeFilter`.
+- An `onError` remote function for the file service.
+- Content-binding remote functions such as `onFileJson` for the file listener.
+- Chained or conditional actions.
+
+## Design
+
+### 1. Action types
+
+```ballerina
+# Delete action for file processing. When specified, the file is deleted after processing.
+public const DELETE = "DELETE";
+
+# Configuration for moving a file after processing.
+public type Move record {|
+    # Destination directory the file is moved into
+    string moveTo;
+    # If `true`, keeps the subdirectory path relative to the listener's `path` under `moveTo`
+    boolean preserveSubDirs = true;
+|};
+
+# Type alias for the `Move` record, used in the action unions.
+public type MOVE Move;
+```
+
+### 2. Annotation
+
+```ballerina
+# Configuration for the remote functions of a file service.
+public type FunctionConfiguration record {|
+    # Action to perform after the remote function returns successfully. Can be `DELETE` or `MOVE`.
+    # If not specified, no action is taken and the file remains in place
+    MOVE|DELETE afterProcess?;
+    # Action to perform after the remote function returns an error or panics. Can be `DELETE` or `MOVE`.
+    # If not specified, no action is taken and the file remains in place
+    MOVE|DELETE afterError?;
+|};
+
+# Annotation to configure the remote functions of a file service.
+public annotation FunctionConfiguration FunctionConfig on service remote function;
+```
+
+The annotation can be attached to `onCreate` and `onModify`. Attaching it to `onDelete` is a compile-time error. Attaching such a service to a listener at runtime fails with an error.
+
+### 3. Behavior
+
+When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. Only one action runs per invocation. If the relevant field is not set, the file is left in place.
+
+The action runs as soon as the remote function returns.
+
+`DELETE` removes the file.
+
+`MOVE` moves the file into the `moveTo` directory. With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. With `false`, the file is placed directly in `moveTo` under its own name. Missing directories on the destination path are created. If a file with the same name already exists at the destination, the move fails, the failure is logged, and the source file stays in place.
+
+For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
+
+The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory.
+
+Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, or when the listener is recursive and `moveTo` is inside the watched directory. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
+
+Only regular files are acted on. A create event for a new subdirectory invokes the remote function but skips the action.
+
+A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped.
+
+Moving or deleting the file emits a delete event for the source path. If the service declares `onDelete`, it is invoked for that event.
+
+When several services attached to the same listener configure actions for the same event, the first action to run acts on the file and the others are skipped.
+
+### 4. Usage examples
+
+#### Example 1: Delete after processing
+
+```ballerina
+service on fileListener {
+    @file:FunctionConfig {
+        afterProcess: file:DELETE
+    }
+    remote function onCreate(file:FileEvent event) returns error? {
+        check process(event.name);
+    }
+}
+```
+
+#### Example 2: Archive on success, quarantine on error
+
+```ballerina
+service on fileListener {
+    @file:FunctionConfig {
+        afterProcess: {moveTo: "/data/archive"},
+        afterError: {moveTo: "/data/failed"}
+    }
+    remote function onCreate(file:FileEvent event) returns error? {
+        check process(event.name);
+    }
+}
+```
+
+#### Example 3: Flatten into one directory
+
+```ballerina
+listener file:Listener fileListener = new (path = "/data/in", recursive = true);
+
+service on fileListener {
+    @file:FunctionConfig {
+        afterProcess: {moveTo: "/data/archive", preserveSubDirs: false}
+    }
+    remote function onCreate(file:FileEvent event) returns error? {
+        check process(event.name);
+    }
+}
+```
+
+#### Example 4: Different actions for create and modify
+
+```ballerina
+service on fileListener {
+    @file:FunctionConfig {
+        afterProcess: {moveTo: "/data/archive"}
+    }
+    remote function onCreate(file:FileEvent event) returns error? {
+        check importNew(event.name);
+    }
+
+    @file:FunctionConfig {
+        afterError: {moveTo: "/data/failed"}
+    }
+    remote function onModify(file:FileEvent event) returns error? {
+        check reimport(event.name);
+    }
+}
+```
+
+## Alternatives
+
+- Manual handling in each remote function. Rejected: this is the boilerplate the feature removes.
+- Options on `file:ListenerConfig`. Rejected: actions differ per remote function, and a listener can host several services.
+
+## Testing
+
+1. `DELETE` after a successful `onCreate` removes the file.
+2. `MOVE` after a successful `onCreate` places the file under `moveTo`, creating missing directories.
+3. `MOVE` with `preserveSubDirs: true` on a recursive listener keeps the subdirectory path; with `false` it does not.
+4. `DELETE` and `MOVE` after `onCreate` returns an error, and after it panics.
+5. Only one of `afterProcess` and `afterError` runs when both are set.
+6. A destination file that already exists causes the move to fail and leaves the source in place.
+7. A directory create event runs the remote function but skips the action.
+8. The action is skipped without error when the remote function has already moved the file.
+9. `onDelete` is invoked for the delete event caused by an action.
+10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, and for `moveTo` inside a recursively watched directory. Attach succeeds for a subdirectory of a non-recursive watched directory.
+11. Two services with actions on the same event: the file is acted on once and neither service fails.
+12. Services without the annotation behave as before.
+13. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, recognised through an import alias, and a user-defined annotation with the same name is not flagged.
+
+## Risks and Assumptions
+
+- A create event is emitted when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
+- A move across file systems is a copy followed by a delete and is not atomic.
+- The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
+- Services without the annotation are unaffected.
+
+## Dependencies
+
+None. The low-code trigger metadata shipped with the module is updated in the same change.
+
+## Future Work
+
+- File name filtering on the listener, tracked in [ballerina-library#8748](https://github.com/ballerina-platform/ballerina-library/issues/8748).
+- Age-based file filtering, matching the FTP listener's `fileAgeFilter`.
+- Content-binding remote functions for the file listener. The annotation applies to them without change.
+
+## References
+
+- Tracking issue: [ballerina-library#9146](https://github.com/ballerina-platform/ballerina-library/issues/9146)
+- FTP post-processing actions: [ballerina-library#8604](https://github.com/ballerina-platform/ballerina-library/issues/8604) and the FTP library specification, section "Post-Processing Actions"
+- FTP proposal for the same feature: [ballerina-spec#1432](https://github.com/ballerina-platform/ballerina-spec/issues/1432)

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -22,8 +22,8 @@ The `ftp:Listener` already provides this through `@ftp:FunctionConfig`. Users wh
 - Run an action after a remote function returns successfully.
 - Run a separate action after a remote function returns an error or panics.
 - Support `DELETE` and `MOVE` actions.
-- Use the same annotation name, field names, and value shapes as `@ftp:FunctionConfig`.
-- Keep services without the annotation unchanged.
+- Use the same annotation name as `@ftp:FunctionConfig`, and the same names and value shapes for its `afterProcess` and `afterError` fields.
+- Keep listeners whose services carry no annotation unchanged.
 
 ## Non-Goals
 
@@ -70,11 +70,11 @@ public type FunctionConfiguration record {|
 public annotation FunctionConfiguration FunctionConfig on service remote function;
 ```
 
-The annotation can be attached to `onCreate` and `onModify`. Attaching it to `onDelete` is a compile-time error. Attaching such a service to a listener at runtime fails with an error.
+The annotation is valid on `onCreate` and `onModify` only. Attaching it to `onDelete` is a compile-time error. Attaching such a service to a listener at runtime fails with an error.
 
 ### 3. Behavior
 
-When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. Only one action runs per invocation. If the relevant field is not set, the file is left in place.
+When the remote function returns `()`, the `afterProcess` action runs. When it returns an error or panics, the error is printed and the `afterError` action runs. At most one action runs per invocation. If the relevant field is not set, the file is left in place.
 
 The action runs as soon as the remote function returns.
 
@@ -84,7 +84,7 @@ The action runs as soon as the remote function returns.
 
 For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
 
-The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory.
+The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory, with symbolic links resolved. `moveTo` is not relative to the watched directory.
 
 Attaching a service fails with an error when `moveTo` is empty, when `moveTo` is the watched directory, or when the listener is recursive and `moveTo` is inside the watched directory. With `recursive: false`, a subdirectory of the watched directory such as `in/processed` is a valid destination.
 
@@ -92,9 +92,9 @@ Only regular files are acted on. A create event for a new subdirectory invokes t
 
 A failure of the action itself is logged and is not reported to the service. The file stays in place. If the file is no longer present when the action runs, the action is skipped.
 
-Moving or deleting the file emits a delete event for the source path. If the service declares `onDelete`, it is invoked for that event.
+Moving or deleting the file emits a delete event for the source path. Every service attached to the listener receives it, and `onDelete` is invoked where declared.
 
-When several services attached to the same listener configure actions for the same event, the first action to run acts on the file and the others are skipped.
+When several services are attached to the same listener, a remote function of one service may run after an action of another service has already moved or deleted the file. The first action to run acts on the file and the others are skipped.
 
 ### 4. Usage examples
 
@@ -178,7 +178,7 @@ service on fileListener {
 9. `onDelete` is invoked for the delete event caused by an action.
 10. Attach fails for an empty `moveTo`, for `moveTo` equal to the watched directory, and for `moveTo` inside a recursively watched directory. Attach succeeds for a subdirectory of a non-recursive watched directory.
 11. Two services with actions on the same event: the file is acted on once and neither service fails.
-12. Services without the annotation behave as before.
+12. A listener whose services carry no annotation behaves as before.
 13. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, recognised through an import alias, and a user-defined annotation with the same name is not flagged.
 
 ## Risks and Assumptions
@@ -186,7 +186,7 @@ service on fileListener {
 - A create event is emitted when a file is created, before the writer has finished. An action on `onCreate` or `onModify` can act on an incomplete file. This proposal assumes a single producer that writes each file completely before it is handled. Producers should write to a temporary name and rename on completion.
 - A move across file systems is a copy followed by a delete and is not atomic.
 - The process needs permission to move or delete files in the watched directory and to create files in `moveTo`.
-- Services without the annotation are unaffected.
+- A listener whose services carry no annotation is unaffected.
 
 ## Dependencies
 

--- a/beps/lib-file/1501_post_processing_actions.md
+++ b/beps/lib-file/1501_post_processing_actions.md
@@ -84,13 +84,24 @@ Different services on one listener may configure different remote functions. An 
 
 **`DELETE`.** The file is removed.
 
-**`MOVE`.** The file is moved into the `moveTo` directory. With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. With `false`, the file is placed directly in `moveTo` under its own name, and files with the same name from different subdirectories collide there. On a non-recursive listener, `preserveSubDirs` has no effect. Directories missing on the destination path are created when the action runs; if they cannot be created, the action fails and is logged. If an entry with the destination name already exists, the move fails, the failure is logged, and the source file stays in place. If the computed destination is inside a recursively watched directory, the move fails and is logged.
+**`MOVE`.** The file is moved into the `moveTo` directory.
+- With `preserveSubDirs` set to `true`, the default, the file keeps its path relative to the listener's `path`. On a non-recursive listener the flag has no effect.
+- With `false`, the file is placed directly in `moveTo` under its own name; files with the same name from different subdirectories collide there.
+- Directories missing on the destination path are created when the action runs. If they cannot be created, the action fails and is logged.
+- If an entry with the destination name already exists, the move fails, the failure is logged, and the source file stays in place.
+- If the computed destination is inside a recursively watched directory, the move fails and is logged.
 
 For example, the listener watches `/data/in` with `recursive: true`, and `/data/in/orders/2026/a.csv` is handled with `afterProcess: {moveTo: "/data/archive"}`. With `preserveSubDirs: true` the file ends at `/data/archive/orders/2026/a.csv`. With `preserveSubDirs: false` it ends at `/data/archive/a.csv`.
 
 **Paths.** The listener's `path`, the event's file path, and `moveTo` are resolved to absolute paths against the working directory. `moveTo` is not relative to the watched directory. For the attach-time checks, symbolic links in the listener's `path` and in `moveTo` are resolved first. The action uses the event's file path as delivered: links in parent directories are traversed, and a link as the final path component is skipped.
 
-**Attach-time checks.** Attaching a service fails with an error when the annotation is present on `onDelete`, when `moveTo` is empty, when `moveTo` exists and is not a directory, when `moveTo` is the watched directory, when the listener is recursive and `moveTo` is inside the watched directory, or when another service on the listener already configures an action for the same remote function. With `recursive: false`, a subdirectory of the watched directory such as `/data/in/processed` is a valid destination; creating it produces a create event for the directory, which invokes the remote function and skips the action.
+**Attach-time checks.** Attaching a service fails with an error when:
+- the annotation is present on `onDelete`;
+- `moveTo` is empty, or exists and is not a directory;
+- `moveTo` is the watched directory, or the listener is recursive and `moveTo` is inside it;
+- another service on the listener already configures an action for the same remote function.
+
+With `recursive: false`, a subdirectory of the watched directory such as `/data/in/processed` is a valid destination. Creating it produces a create event for the directory, which invokes the remote function and skips the action.
 
 **What is acted on.** Only regular files are acted on. Directories and symbolic links are skipped: a create event for a new subdirectory or for a link invokes the remote function but skips the action. The action acts on the regular file at the path when it runs, whether or not it is the file that produced the event.
 
@@ -177,34 +188,23 @@ service on fileListener {
 
 ## Testing
 
-1. `DELETE` after a successful `onCreate` removes the file.
-2. `MOVE` after a successful `onCreate` places the file under `moveTo`, creating missing directories.
-3. `MOVE` with `preserveSubDirs: true` on a recursive listener keeps the subdirectory path; with `false` it does not.
-4. `DELETE` and `MOVE` after `onCreate` returns an error, and after it panics.
-5. `DELETE` and `MOVE` on `onModify` after success, after an error, and after a panic.
-6. Only one of `afterProcess` and `afterError` runs when both are set.
-7. An entry that already exists at the destination causes the move to fail and leaves the source in place.
-8. A create event for a directory or for a symbolic link runs the remote function but skips the action.
-9. The action is skipped without error when the remote function has already moved the file.
-10. `onDelete` is invoked for the delete event caused by an action, both in the service that configured the action and in a second service on the same listener that carries no annotation.
-11. Attach fails for the annotation on `onDelete`, for an empty `moveTo`, for a `moveTo` that exists and is not a directory, for `moveTo` equal to the watched directory, for `moveTo` inside a recursively watched directory, for a `moveTo` symbolic link that points into a recursively watched directory, and for a second service configuring the same remote function on the same listener.
-12. Attach succeeds for a subdirectory of a non-recursive watched directory. The first move creates it; the directory create event runs the remote function and skips the action.
-13. A relative `moveTo` resolves against the working directory.
-14. A computed destination inside a recursively watched directory fails and is logged.
-15. An action failure other than a collision, such as `DELETE` in a directory without write permission, is logged and leaves the file in place.
-16. A file that produces a create event and a modify event, both with actions: the first action removes the file and the second is skipped.
-17. Two services on one listener, one with an action on `onCreate` and one without: both remote functions run with the file in place, then the file is acted on once.
-18. An annotation with neither field set is accepted and configures nothing.
-19. After a service is detached, another service can configure the same remote function.
-20. A listener whose services carry no annotation behaves as before.
-21. Compiler plugin: the annotation is accepted on `onCreate` and `onModify`, rejected on `onDelete`, rejected on a second service configuring the same remote function on the same listener, recognized through an import alias, and a user-defined annotation with the same name is not flagged.
+1. `DELETE` and `MOVE` after success, after an error, and after a panic, on `onCreate` and on `onModify`; only one of the two actions runs when both are set.
+2. `preserveSubDirs` `true` and `false` on a recursive listener; no effect on a non-recursive listener.
+3. Missing destination directories are created; an existing entry at the destination fails the move; a computed destination inside a recursively watched directory fails the move.
+4. Directory and symbolic-link events skip the action; a file already moved by the remote function skips the action; an action failure such as `DELETE` without write permission is logged and leaves the file in place.
+5. The delete event caused by an action reaches every attached service, including one with no annotation.
+6. Each attach-time rejection listed under Behavior, and success for a subdirectory of a non-recursive watched directory, including the create event for that directory.
+7. Two services on one listener, one with an action and one without; a create followed by a modify event on one file; two listeners on one directory.
+8. An annotation with neither field set; detach and re-attach of the configuring service; a relative `moveTo`.
+9. A listener whose services carry no annotation behaves as before.
+10. Compiler plugin: accepted on `onCreate` and `onModify`, rejected on `onDelete` and on a second service configuring the same remote function on the same listener, recognized through an import alias, and a user-defined annotation with the same name is not flagged.
 
 Moves across file systems are not covered by automated tests.
 
 ## Risks and Assumptions
 
 - A create event may arrive before the writer has finished, and each write may produce a further modify event. This proposal assumes each file is complete when its event is delivered. Producers write the file outside the watched directory, on the same file system, and move it into the watched directory when complete.
-- A move across file systems is a copy followed by a delete and is not atomic. On Linux and macOS, if the copy fails, no partial destination is left and the source stays in place; if the copy succeeds but the source cannot be deleted, the copy is removed and the source stays in place. On Windows, if the copy succeeds but the source cannot be deleted, both files remain, and a later action on the same file follows the collision rule.
+- A move across file systems is a copy followed by a delete and is not atomic. On Linux and macOS, a failed copy leaves no partial destination. A failed source delete after a successful copy removes the copy. The source stays in place in both cases. On Windows, if the copy succeeds but the source cannot be deleted, both files remain, and a later action on the same file follows the collision rule.
 - The process needs write permission on the directory containing the file, on `moveTo`, and on any directory it creates under `moveTo`.
 - A listener whose services carry no annotation is unaffected.
 


### PR DESCRIPTION
## Purpose
Adds a Ballerina Enhancement Proposal for post-processing actions (`afterProcess` and `afterError`) on the `file:Listener`, matching `@ftp:FunctionConfig`. Introduces `beps/lib-file`.

Discussion issue: #1501. Tracking issue: ballerina-platform/ballerina-library#9146.

## Goals
Declarative move or delete of a file after a `file:Listener` remote function completes, with separate actions for success and error.

## Approach
Proposal document only; see the BEP file.

## User stories
An integration developer archives or discards each processed file without writing file handling in every remote function.

## Release note
N/A, proposal only.

## Documentation
N/A, the BEP is the document. The module specification is updated with the implementation.

## Training
N/A

## Certification
N/A, no exam impact.

## Marketing
N/A

## Automation tests
N/A, proposal only. Test scenarios are listed in the BEP.

## Security checks
- Followed secure coding standards: N/A, no code
- Ran FindSecurityBugs plugin: N/A, no code
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Usage examples are in the BEP.

## Related PRs
None yet; the implementation follows in module-ballerina-file.

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A
